### PR TITLE
Add .txt file settings panel

### DIFF
--- a/Source/LegacyProject.cpp
+++ b/Source/LegacyProject.cpp
@@ -124,6 +124,18 @@ void OscirenderAudioProcessor::openLegacyProject(const juce::XmlElement* xml) {
             juce::Base64::convertFromBase64(stream, perspectiveFunction->getAllSubText());
             perspectiveEffect->updateCode(stream.toString());
         }
+
+        auto fontFamilyXml = xml->getChildByName("fontFamily");
+        if (fontFamilyXml != nullptr) {
+            font.setTypefaceName(fontFamilyXml->getAllSubText());
+        }
+        auto fontStyleXml = xml->getChildByName("fontStyle");
+        if (fontStyleXml != nullptr) {
+            int style = fontStyleXml->getAllSubText().getIntValue();
+            font.setBold(style == 1);
+            font.setItalic(style == 2);
+        }
+
         // close all files
         auto numFiles = fileBlocks.size();
         for (int i = 0; i < numFiles; i++) {

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -8,6 +8,7 @@ OscirenderAudioProcessorEditor::OscirenderAudioProcessorEditor(OscirenderAudioPr
     addAndMakeVisible(main);
     addChildComponent(lua);
     addChildComponent(obj);
+    addChildComponent(txt);
     addAndMakeVisible(volume);
 
     menuBar.setModel(&menuBarModel);
@@ -135,10 +136,11 @@ void OscirenderAudioProcessorEditor::resized() {
     
     auto effectsSection = area.removeFromRight(1.2 * getWidth() / sections);
     main.setBounds(area.reduced(5));
-    if (lua.isVisible() || obj.isVisible()) {
-        auto altEffectsSection = effectsSection.removeFromBottom(juce::jmin(effectsSection.getHeight() / 2, 300));
+    if (lua.isVisible() || obj.isVisible() || txt.isVisible()) {
+        auto altEffectsSection = effectsSection.removeFromBottom(juce::jmin(effectsSection.getHeight() / 2, txt.isVisible() ? 150 : 300));
         lua.setBounds(altEffectsSection.reduced(5));
         obj.setBounds(altEffectsSection.reduced(5));
+        txt.setBounds(altEffectsSection.reduced(5));
     }
 	effects.setBounds(effectsSection.reduced(5));
 
@@ -214,13 +216,16 @@ void OscirenderAudioProcessorEditor::fileUpdated(juce::String fileName) {
     juce::String extension = fileName.fromLastOccurrenceOf(".", true, false);
     lua.setVisible(false);
     obj.setVisible(false);
+    txt.setVisible(false);
     if (fileName.isEmpty()) {
         // do nothing
     } else if (extension == ".lua") {
         lua.setVisible(true);
     } else if (extension == ".obj") {
 		obj.setVisible(true);
-	}
+    } else if (extension == ".txt") {
+        txt.setVisible(true);
+    }
     main.updateFileLabel();
     updateCodeEditor();
 }

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -69,8 +69,8 @@ OscirenderAudioProcessorEditor::~OscirenderAudioProcessorEditor() {
 
 // parsersLock must be held
 void OscirenderAudioProcessorEditor::initialiseCodeEditors() {
-    codeDocuments.clear();
     codeEditors.clear();
+    codeDocuments.clear();
     // -1 is the perspective function
     addCodeEditor(-1);
     for (int i = 0; i < audioProcessor.numFiles(); i++) {
@@ -237,6 +237,7 @@ void OscirenderAudioProcessorEditor::handleAsyncUpdate() {
 void OscirenderAudioProcessorEditor::changeListenerCallback(juce::ChangeBroadcaster* source) {
     juce::SpinLock::ScopedLockType lock(audioProcessor.parsersLock);
     initialiseCodeEditors();
+    txt.update();
 }
 
 void OscirenderAudioProcessorEditor::editPerspectiveFunction(bool enable) {

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -6,6 +6,7 @@
 #include "MainComponent.h"
 #include "LuaComponent.h"
 #include "ObjComponent.h"
+#include "TxtComponent.h"
 #include "components/VolumeComponent.h"
 #include "components/MainMenuBarModel.h"
 #include "LookAndFeel.h"
@@ -43,6 +44,7 @@ private:
     MainComponent main{audioProcessor, *this};
     LuaComponent lua{audioProcessor, *this};
     ObjComponent obj{audioProcessor, *this};
+    TxtComponent txt{audioProcessor, *this};
     EffectsComponent effects{audioProcessor, *this};
     VolumeComponent volume{audioProcessor};
     std::vector<std::shared_ptr<juce::CodeDocument>> codeDocuments;

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -355,7 +355,8 @@ void OscirenderAudioProcessor::openFile(int index) {
 	if (index < 0 || index >= fileBlocks.size()) {
 		return;
 	}
-    parsers[index]->parse(fileNames[index].fromLastOccurrenceOf(".", true, false), std::make_unique<juce::MemoryInputStream>(*fileBlocks[index], false));
+    juce::SpinLock::ScopedLockType lock(fontLock);
+    parsers[index]->parse(fileNames[index].fromLastOccurrenceOf(".", true, false), std::make_unique<juce::MemoryInputStream>(*fileBlocks[index], false), font);
     changeCurrentFile(index);
 }
 

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -180,6 +180,9 @@ public:
     // so should only be accessed by message thread
     juce::String currentProjectFile;
 
+    juce::SpinLock fontLock;
+    juce::Font font = juce::Font(juce::Font::getDefaultSansSerifFontName(), 1.0f, juce::Font::plain);
+
     void addLuaSlider();
     void addFrame(std::vector<std::unique_ptr<Shape>> frame, int fileIndex) override;
     void updateEffectPrecedence();
@@ -190,6 +193,7 @@ public:
     void removeFile(int index);
     int numFiles();
     void changeCurrentFile(int index);
+    void openFile(int index);
     int getCurrentFileIndex();
     std::shared_ptr<FileParser> getCurrentFileParser();
 	juce::String getCurrentFileName();
@@ -244,7 +248,6 @@ private:
 	void updateFrame();
     void updateLengthIncrement();
     void incrementShapeDrawing();
-    void openFile(int index);
     void updateLuaValues();
     void updateObjValues();
     std::shared_ptr<Effect> getEffect(juce::String id);

--- a/Source/TxtComponent.cpp
+++ b/Source/TxtComponent.cpp
@@ -1,0 +1,51 @@
+#include "TxtComponent.h"
+#include "PluginEditor.h"
+
+TxtComponent::TxtComponent(OscirenderAudioProcessor& p, OscirenderAudioProcessorEditor& editor) : audioProcessor(p), pluginEditor(editor) {
+	setText(".txt File Settings");
+
+	addAndMakeVisible(font);
+	addAndMakeVisible(bold);
+	addAndMakeVisible(italic);
+
+	for (int i = 0; i < installedFonts.size(); i++) {
+        font.addItem(installedFonts[i], i + 1);
+    }
+
+	{
+		juce::SpinLock::ScopedLockType lock(audioProcessor.fontLock);
+		juce::String defaultFont = audioProcessor.font.getTypefaceName();
+		int index = installedFonts.indexOf(defaultFont);
+		if (index == -1) {
+			index = 0;
+		}
+		font.setSelectedItemIndex(index);
+		bold.setToggleState(audioProcessor.font.isBold(), juce::dontSendNotification);
+		italic.setToggleState(audioProcessor.font.isItalic(), juce::dontSendNotification);
+	}
+
+	auto updateFont = [this]() {
+		juce::SpinLock::ScopedLockType lock1(audioProcessor.parsersLock);
+		juce::SpinLock::ScopedLockType lock2(audioProcessor.effectsLock);
+		{
+			juce::SpinLock::ScopedLockType lock3(audioProcessor.fontLock);
+			audioProcessor.font.setTypefaceName(installedFonts[font.getSelectedItemIndex()]);
+			audioProcessor.font.setBold(bold.getToggleState());
+			audioProcessor.font.setItalic(italic.getToggleState());
+		}
+		
+		audioProcessor.openFile(audioProcessor.currentFile);
+    };
+
+	font.onChange = updateFont;
+	bold.onClick = updateFont;
+	italic.onClick = updateFont;
+}
+
+void TxtComponent::resized() {
+	auto area = getLocalBounds().withTrimmedTop(20).reduced(20);
+	double rowHeight = 30;
+	font.setBounds(area.removeFromTop(rowHeight));
+	bold.setBounds(area.removeFromTop(rowHeight));
+	italic.setBounds(area.removeFromTop(rowHeight));
+}

--- a/Source/TxtComponent.cpp
+++ b/Source/TxtComponent.cpp
@@ -12,17 +12,7 @@ TxtComponent::TxtComponent(OscirenderAudioProcessor& p, OscirenderAudioProcessor
         font.addItem(installedFonts[i], i + 1);
     }
 
-	{
-		juce::SpinLock::ScopedLockType lock(audioProcessor.fontLock);
-		juce::String defaultFont = audioProcessor.font.getTypefaceName();
-		int index = installedFonts.indexOf(defaultFont);
-		if (index == -1) {
-			index = 0;
-		}
-		font.setSelectedItemIndex(index);
-		bold.setToggleState(audioProcessor.font.isBold(), juce::dontSendNotification);
-		italic.setToggleState(audioProcessor.font.isItalic(), juce::dontSendNotification);
-	}
+	update();
 
 	auto updateFont = [this]() {
 		juce::SpinLock::ScopedLockType lock1(audioProcessor.parsersLock);
@@ -48,4 +38,16 @@ void TxtComponent::resized() {
 	font.setBounds(area.removeFromTop(rowHeight));
 	bold.setBounds(area.removeFromTop(rowHeight));
 	italic.setBounds(area.removeFromTop(rowHeight));
+}
+
+void TxtComponent::update() {
+	juce::SpinLock::ScopedLockType lock(audioProcessor.fontLock);
+    juce::String defaultFont = audioProcessor.font.getTypefaceName();
+    int index = installedFonts.indexOf(defaultFont);
+	if (index == -1) {
+        index = 0;
+    }
+    font.setSelectedItemIndex(index);
+    bold.setToggleState(audioProcessor.font.isBold(), juce::dontSendNotification);
+    italic.setToggleState(audioProcessor.font.isItalic(), juce::dontSendNotification);
 }

--- a/Source/TxtComponent.h
+++ b/Source/TxtComponent.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <JuceHeader.h>
+#include "PluginProcessor.h"
+
+class OscirenderAudioProcessorEditor;
+class TxtComponent : public juce::GroupComponent, public juce::MouseListener {
+public:
+    TxtComponent(OscirenderAudioProcessor&, OscirenderAudioProcessorEditor&);
+
+    void resized() override;
+private:
+    OscirenderAudioProcessor& audioProcessor;
+    OscirenderAudioProcessorEditor& pluginEditor;
+
+    juce::StringArray installedFonts = juce::Font::findAllTypefaceNames();
+
+    juce::ComboBox font;
+    juce::ToggleButton bold{"Bold"};
+    juce::ToggleButton italic{"Italic"};
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(TxtComponent)
+};

--- a/Source/TxtComponent.h
+++ b/Source/TxtComponent.h
@@ -9,6 +9,7 @@ public:
     TxtComponent(OscirenderAudioProcessor&, OscirenderAudioProcessorEditor&);
 
     void resized() override;
+    void update();
 private:
     OscirenderAudioProcessor& audioProcessor;
     OscirenderAudioProcessorEditor& pluginEditor;

--- a/Source/parser/FileParser.cpp
+++ b/Source/parser/FileParser.cpp
@@ -5,7 +5,7 @@
 
 FileParser::FileParser() {}
 
-void FileParser::parse(juce::String extension, std::unique_ptr<juce::InputStream> stream) {
+void FileParser::parse(juce::String extension, std::unique_ptr<juce::InputStream> stream, juce::Font font) {
 	juce::SpinLock::ScopedLockType scope(lock);
 
 	object = nullptr;
@@ -21,7 +21,7 @@ void FileParser::parse(juce::String extension, std::unique_ptr<juce::InputStream
 	} else if (extension == ".svg") {
 		svg = std::make_shared<SvgParser>(stream->readEntireStreamAsString());
 	} else if (extension == ".txt") {
-		text = std::make_shared<TextParser>(stream->readEntireStreamAsString(), juce::Font(1.0f));
+		text = std::make_shared<TextParser>(stream->readEntireStreamAsString(), font);
 	} else if (extension == ".lua") {
 		lua = std::make_shared<LuaParser>(stream->readEntireStreamAsString());
 	}

--- a/Source/parser/FileParser.h
+++ b/Source/parser/FileParser.h
@@ -8,17 +8,17 @@
 #include "../txt/TextParser.h"
 #include "../lua/LuaParser.h"
 
-class FileParser : public FrameSource {
+class FileParser {
 public:
 	FileParser();
 
-	void parse(juce::String extension, std::unique_ptr<juce::InputStream>) override;
-	std::vector<std::unique_ptr<Shape>> nextFrame() override;
-	Vector2 nextSample() override;
-	bool isSample() override;
-	bool isActive() override;
-	void disable() override;
-	void enable() override;
+	void parse(juce::String extension, std::unique_ptr<juce::InputStream>, juce::Font);
+	std::vector<std::unique_ptr<Shape>> nextFrame();
+	Vector2 nextSample();
+	bool isSample();
+	bool isActive();
+	void disable();
+	void enable();
 
 	std::shared_ptr<WorldObject> getObject();
 	std::shared_ptr<Camera> getCamera();

--- a/Source/parser/FrameProducer.cpp
+++ b/Source/parser/FrameProducer.cpp
@@ -1,6 +1,6 @@
 #include "FrameProducer.h"
 
-FrameProducer::FrameProducer(FrameConsumer& fc, std::shared_ptr<FrameSource> fs) : frameConsumer(fc), frameSource(fs), juce::Thread("producer", 0) {}
+FrameProducer::FrameProducer(FrameConsumer& fc, std::shared_ptr<FileParser> fs) : frameConsumer(fc), frameSource(fs), juce::Thread("producer", 0) {}
 
 FrameProducer::~FrameProducer() {
 	frameSource->disable();
@@ -15,7 +15,7 @@ void FrameProducer::run() {
 	}
 }
 
-void FrameProducer::setSource(std::shared_ptr<FrameSource> source, int fileIndex) {
+void FrameProducer::setSource(std::shared_ptr<FileParser> source, int fileIndex) {
 	juce::SpinLock::ScopedLockType scope(lock);
 	frameSource->disable();
 	frameSource = source;

--- a/Source/parser/FrameProducer.h
+++ b/Source/parser/FrameProducer.h
@@ -1,19 +1,19 @@
 #pragma once
 
 #include <JuceHeader.h>
-#include "FrameSource.h"
+#include "FileParser.h"
 #include "FrameConsumer.h"
 
 class FrameProducer : public juce::Thread {
 public:
-	FrameProducer(FrameConsumer&, std::shared_ptr<FrameSource>);
+	FrameProducer(FrameConsumer&, std::shared_ptr<FileParser>);
 	~FrameProducer() override;
 
 	void run() override;
-	void setSource(std::shared_ptr<FrameSource>, int fileIndex);
+	void setSource(std::shared_ptr<FileParser>, int fileIndex);
 private:
 	juce::SpinLock lock;
 	FrameConsumer& frameConsumer;
-	std::shared_ptr<FrameSource> frameSource;
+	std::shared_ptr<FileParser> frameSource;
 	int sourceFileIndex = -1;
 };

--- a/Source/parser/FrameSource.h
+++ b/Source/parser/FrameSource.h
@@ -7,7 +7,6 @@
 
 class FrameSource {
 public:
-	virtual void parse(juce::String extension, std::unique_ptr<juce::InputStream>) = 0;
 	virtual std::vector<std::unique_ptr<Shape>> nextFrame() = 0;
 	virtual Vector2 nextSample() = 0;
 	virtual bool isSample() = 0;

--- a/osci-render.jucer
+++ b/osci-render.jucer
@@ -435,6 +435,9 @@
         <FILE id="vIYWRG" name="TextParser.cpp" compile="1" resource="0" file="Source/txt/TextParser.cpp"/>
         <FILE id="LlefOK" name="TextParser.h" compile="0" resource="0" file="Source/txt/TextParser.h"/>
       </GROUP>
+      <FILE id="UxZu4n" name="TxtComponent.cpp" compile="1" resource="0"
+            file="Source/TxtComponent.cpp"/>
+      <FILE id="kxPbsL" name="TxtComponent.h" compile="0" resource="0" file="Source/TxtComponent.h"/>
     </GROUP>
   </MAINGROUP>
   <JUCEOPTIONS JUCE_STRICT_REFCOUNTEDPOINTER="1" JUCE_VST3_CAN_REPLACE_VST2="0"/>


### PR DESCRIPTION
![image](https://github.com/jameshball/osci-render-juce/assets/38670946/0a48b3a8-4004-4d3a-a8ef-57ac70e7e7ea)

Fonts along with bold/italic can now be chosen and they are saved/loaded to project files (including legacy project files)