### PR TITLE
Fix Blender when using MIDI, and change default MIDI enabled

### DIFF
--- a/Source/MidiComponent.cpp
+++ b/Source/MidiComponent.cpp
@@ -4,6 +4,8 @@
 MidiComponent::MidiComponent(OscirenderAudioProcessor& p, OscirenderAudioProcessorEditor& editor) : audioProcessor(p), pluginEditor(editor) {
     addAndMakeVisible(midiToggle);
     addAndMakeVisible(keyboard);
+
+    midiToggle.setToggleState(audioProcessor.midiEnabled->getBoolValue(), juce::dontSendNotification);
     
     midiToggle.onClick = [this]() {
         audioProcessor.midiEnabled->setBoolValueNotifyingHost(midiToggle.getToggleState());

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -177,7 +177,7 @@ public:
     std::shared_ptr<DelayEffect> delayEffect = std::make_shared<DelayEffect>();
     std::shared_ptr<PerspectiveEffect> perspectiveEffect = std::make_shared<PerspectiveEffect>(VERSION_HINT);
     
-    BooleanParameter* midiEnabled = new BooleanParameter("MIDI Enabled", "midiEnabled", VERSION_HINT, false);
+    BooleanParameter* midiEnabled = new BooleanParameter("MIDI Enabled", "midiEnabled", VERSION_HINT, !juce::JUCEApplicationBase::isStandaloneApp());
     std::atomic<float> frequency = 440.0f;
     
     juce::SpinLock parsersLock;

--- a/Source/audio/ShapeSound.cpp
+++ b/Source/audio/ShapeSound.cpp
@@ -26,8 +26,12 @@ bool ShapeSound::appliesToChannel(int channel) {
     return true;
 }
 
-void ShapeSound::addFrame(std::vector<std::unique_ptr<Shape>>& frame) {
-    frames.push(std::move(frame));
+void ShapeSound::addFrame(std::vector<std::unique_ptr<Shape>>& frame, bool force) {
+    if (force) {
+        frames.push(std::move(frame));
+    } else {
+        frames.try_push(std::move(frame));
+    }
 }
 
 double ShapeSound::updateFrame(std::vector<std::unique_ptr<Shape>>& frame) {

--- a/Source/audio/ShapeSound.h
+++ b/Source/audio/ShapeSound.h
@@ -13,7 +13,7 @@ public:
 
 	bool appliesToNote(int note) override;
 	bool appliesToChannel(int channel) override;
-	void addFrame(std::vector<std::unique_ptr<Shape>>& frame) override;
+	void addFrame(std::vector<std::unique_ptr<Shape>>& frame, bool force = true) override;
 	double updateFrame(std::vector<std::unique_ptr<Shape>>& frame);
 
 	std::shared_ptr<FileParser> parser;

--- a/Source/audio/ShapeVoice.cpp
+++ b/Source/audio/ShapeVoice.cpp
@@ -135,7 +135,7 @@ void ShapeVoice::renderNextBlock(juce::AudioSampleBuffer& outputBuffer, int star
         double drawnFrameLength = traceMaxEnabled ? actualTraceMax * frameLength : frameLength;
 
         if (!renderingSample && frameDrawn >= drawnFrameLength) {
-            if (sound.load() != nullptr) {
+            if (sound.load() != nullptr && currentlyPlaying) {
                 frameLength = sound.load()->updateFrame(frame);
             }
             // TODO: updateFrame already iterates over all the shapes,

--- a/Source/obj/ObjectServer.cpp
+++ b/Source/obj/ObjectServer.cpp
@@ -22,7 +22,7 @@ void ObjectServer::run() {
                 if (connection != nullptr) {
                     audioProcessor.setObjectServerRendering(true);
 
-                    while (!threadShouldExit()) {
+                    while (!threadShouldExit() && connection->isConnected()) {
                         if (connection->waitUntilReady(true, 200) == 1) {
                             int i = 0;
 
@@ -177,7 +177,7 @@ void ObjectServer::run() {
                                 }
                             }
 
-                            audioProcessor.objectServerSound->addFrame(frame);
+                            audioProcessor.objectServerSound->addFrame(frame, false);
                         }
                     }
                 }

--- a/Source/parser/FrameConsumer.h
+++ b/Source/parser/FrameConsumer.h
@@ -6,5 +6,5 @@
 
 class FrameConsumer {
 public:
-	virtual void addFrame(std::vector<std::unique_ptr<Shape>>& frame) = 0;
+	virtual void addFrame(std::vector<std::unique_ptr<Shape>>& frame, bool force = true) = 0;
 };


### PR DESCRIPTION
- Blender now works with MIDI
  - Only currently playing notes request new frames, so when you stop playing, the animation stops
    - This could be tweaked in future
- By default, MIDI is enabled if opened as a plugin, and disabled if opened as a standalone app