### PR TITLE
Adds an ADSR envelope for controlling how MIDI notes are played

### DIFF
--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -100,6 +100,8 @@ MainComponent::MainComponent(OscirenderAudioProcessor& p, OscirenderAudioProcess
 			frequencyLabel.setText(juce::String(roundedFrequency) + "Hz", juce::dontSendNotification);
 		}
 	);
+
+	addAndMakeVisible(envelope);
 }
 
 MainComponent::~MainComponent() {
@@ -144,6 +146,7 @@ void MainComponent::resized() {
 	bounds.removeFromTop(padding);
 	openOscilloscope.setBounds(bounds.removeFromBottom(buttonHeight).withSizeKeepingCentre(160, buttonHeight));
 	bounds.removeFromBottom(padding);
+	envelope.setBounds(bounds.removeFromTop(200));
 	auto minDim = juce::jmin(bounds.getWidth(), bounds.getHeight());
 	visualiser.setBounds(bounds.withSizeKeepingCentre(minDim, minDim));
 }

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -100,9 +100,6 @@ MainComponent::MainComponent(OscirenderAudioProcessor& p, OscirenderAudioProcess
 			frequencyLabel.setText(juce::String(roundedFrequency) + "Hz", juce::dontSendNotification);
 		}
 	);
-
-	addAndMakeVisible(envelope);
-	envelope.setEnv(audioProcessor.adsrEnv);
 }
 
 MainComponent::~MainComponent() {
@@ -147,7 +144,6 @@ void MainComponent::resized() {
 	bounds.removeFromTop(padding);
 	openOscilloscope.setBounds(bounds.removeFromBottom(buttonHeight).withSizeKeepingCentre(160, buttonHeight));
 	bounds.removeFromBottom(padding);
-	envelope.setBounds(bounds.removeFromTop(200));
 	auto minDim = juce::jmin(bounds.getWidth(), bounds.getHeight());
 	visualiser.setBounds(bounds.withSizeKeepingCentre(minDim, minDim));
 }

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -102,6 +102,7 @@ MainComponent::MainComponent(OscirenderAudioProcessor& p, OscirenderAudioProcess
 	);
 
 	addAndMakeVisible(envelope);
+	envelope.setEnv(audioProcessor.adsrEnv);
 }
 
 MainComponent::~MainComponent() {

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -33,8 +33,6 @@ private:
 	VisualiserComponent visualiser{2, audioProcessor};
 	juce::TextButton openOscilloscope{"Open Oscilloscope"};
 
-	EnvelopeContainerComponent envelope;
-
 	juce::Label frequencyLabel;
 	int callbackIndex = -1;
 

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -6,6 +6,7 @@
 #include "parser/FrameProducer.h"
 #include "components/VisualiserComponent.h"
 #include "audio/PitchDetector.h"
+#include "UGen/ugen_JuceEnvelopeComponent.h"
 
 class OscirenderAudioProcessorEditor;
 class MainComponent : public juce::GroupComponent {
@@ -31,6 +32,8 @@ private:
 
 	VisualiserComponent visualiser{2, audioProcessor};
 	juce::TextButton openOscilloscope{"Open Oscilloscope"};
+
+	EnvelopeContainerComponent envelope;
 
 	juce::Label frequencyLabel;
 	int callbackIndex = -1;

--- a/Source/MidiComponent.cpp
+++ b/Source/MidiComponent.cpp
@@ -62,6 +62,11 @@ void MidiComponent::handleAsyncUpdate() {
         2
     );
 
+    {
+        juce::SpinLock::ScopedLockType lock(audioProcessor.effectsLock);
+        audioProcessor.adsrEnv = newEnv;
+    }
+
     envelope.setEnv(newEnv);
 }
 

--- a/Source/MidiComponent.cpp
+++ b/Source/MidiComponent.cpp
@@ -16,18 +16,26 @@ MidiComponent::MidiComponent(OscirenderAudioProcessor& p, OscirenderAudioProcess
     envelope.setEnv(audioProcessor.adsrEnv);
     envelope.addListener(&audioProcessor);
 
-    audioProcessor.attack->addListener(this);
-    audioProcessor.decay->addListener(this);
-    audioProcessor.sustain->addListener(this);
-    audioProcessor.release->addListener(this);
+    audioProcessor.attackTime->addListener(this);
+    audioProcessor.attackLevel->addListener(this);
+    audioProcessor.attackShape->addListener(this);
+    audioProcessor.decayTime->addListener(this);
+    audioProcessor.decayShape->addListener(this);
+    audioProcessor.sustainLevel->addListener(this);
+    audioProcessor.releaseTime->addListener(this);
+    audioProcessor.releaseShape->addListener(this);
 }
 
 MidiComponent::~MidiComponent() {
     envelope.removeListener(&audioProcessor);
-    audioProcessor.attack->removeListener(this);
-    audioProcessor.decay->removeListener(this);
-    audioProcessor.sustain->removeListener(this);
-    audioProcessor.release->removeListener(this);
+    audioProcessor.attackTime->removeListener(this);
+    audioProcessor.attackLevel->removeListener(this);
+    audioProcessor.attackShape->removeListener(this);
+    audioProcessor.decayTime->removeListener(this);
+    audioProcessor.decayShape->removeListener(this);
+    audioProcessor.sustainLevel->removeListener(this);
+    audioProcessor.releaseTime->removeListener(this);
+    audioProcessor.releaseShape->removeListener(this);
 }
 
 void MidiComponent::parameterValueChanged(int parameterIndex, float newValue) {
@@ -38,13 +46,20 @@ void MidiComponent::parameterGestureChanged(int parameterIndex, bool gestureIsSt
 
 void MidiComponent::handleAsyncUpdate() {
     DBG("MidiComponent::handleAsyncUpdate");
-    Env newEnv = Env::adsr(
-        audioProcessor.attack->getValueUnnormalised(),
-        audioProcessor.decay->getValueUnnormalised(),
-        audioProcessor.sustain->getValueUnnormalised(),
-        audioProcessor.release->getValueUnnormalised(),
-        1.0,
-        std::vector<EnvCurve>{ audioProcessor.attackShape->getValueUnnormalised(), audioProcessor.decayShape->getValueUnnormalised(), audioProcessor.releaseShape->getValueUnnormalised() }
+    Env newEnv = Env(
+        { 
+            0.0,
+            audioProcessor.attackLevel->getValueUnnormalised(),
+            audioProcessor.sustainLevel->getValueUnnormalised(),
+            0.0
+        },
+        {
+            audioProcessor.attackTime->getValueUnnormalised(),
+            audioProcessor.decayTime->getValueUnnormalised(),
+            audioProcessor.releaseTime->getValueUnnormalised()
+        },
+        std::vector<EnvCurve>{ audioProcessor.attackShape->getValueUnnormalised(), audioProcessor.decayShape->getValueUnnormalised(), audioProcessor.releaseShape->getValueUnnormalised() },
+        2
     );
 
     envelope.setEnv(newEnv);

--- a/Source/MidiComponent.h
+++ b/Source/MidiComponent.h
@@ -4,9 +4,14 @@
 #include "PluginProcessor.h"
 
 class OscirenderAudioProcessorEditor;
-class MidiComponent : public juce::Component {
+class MidiComponent : public juce::Component, public juce::AudioProcessorParameter::Listener, public juce::AsyncUpdater {
 public:
 	MidiComponent(OscirenderAudioProcessor&, OscirenderAudioProcessorEditor&);
+	~MidiComponent() override;
+
+	void parameterValueChanged(int parameterIndex, float newValue) override;
+	void parameterGestureChanged(int parameterIndex, bool gestureIsStarting) override;
+	void handleAsyncUpdate() override;
 
 	void resized() override;
 	void paint(juce::Graphics& g) override;
@@ -17,6 +22,8 @@ private:
 	juce::ToggleButton midiToggle{"Enable MIDI"};
 	juce::MidiKeyboardState keyboardState;
 	juce::MidiKeyboardComponent keyboard{keyboardState, juce::MidiKeyboardComponent::horizontalKeyboard};
+
+	EnvelopeContainerComponent envelope;
 
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MidiComponent)
 };

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -141,10 +141,14 @@ OscirenderAudioProcessor::OscirenderAudioProcessor()
         addParameter(parameter);
     }
 
-    addParameter(attack);
-    addParameter(decay);
-    addParameter(sustain);
-    addParameter(release);
+    addParameter(attackTime);
+    addParameter(attackLevel);
+    addParameter(attackShape);
+    addParameter(decayTime);
+    addParameter(decayShape);
+    addParameter(sustainLevel);
+    addParameter(releaseTime);
+    addParameter(releaseShape);
 
     for (int i = 0; i < 4; i++) {
         synth.addVoice(new ShapeVoice(*this));
@@ -699,6 +703,12 @@ void OscirenderAudioProcessor::parameterValueChanged(int parameterIndex, float n
 
 void OscirenderAudioProcessor::parameterGestureChanged(int parameterIndex, bool gestureIsStarting) {}
 
+void updateIfApproxEqual(FloatParameter* parameter, float newValue) {
+    if (std::abs(parameter->getValueUnnormalised() - newValue) > 0.0001) {
+        parameter->setUnnormalisedValueNotifyingHost(newValue);
+    }
+}
+
 void OscirenderAudioProcessor::envelopeChanged(EnvelopeComponent* changedEnvelope) {
     Env env = changedEnvelope->getEnv();
     std::vector<double> levels = env.getLevels();
@@ -707,27 +717,14 @@ void OscirenderAudioProcessor::envelopeChanged(EnvelopeComponent* changedEnvelop
 
     if (levels.size() == 4 && times.size() == 3 && curves.size() == 3) {
         this->adsrEnv = env;
-        if (attack->getValueUnnormalised() != times[0]) {
-            attack->setUnnormalisedValueNotifyingHost(times[0]);
-        }
-        if (decay->getValueUnnormalised() != times[1]) {
-            decay->setUnnormalisedValueNotifyingHost(times[1]);
-        }
-        if (sustain->getValueUnnormalised() != levels[2]) {
-            sustain->setUnnormalisedValueNotifyingHost(levels[2]);
-        }
-        if (release->getValueUnnormalised() != times[2]) {
-            release->setUnnormalisedValueNotifyingHost(times[2]);
-        }
-        if (attackShape->getValueUnnormalised() != curves[0].getCurve()) {
-            attackShape->setUnnormalisedValueNotifyingHost(curves[0].getCurve());
-        }
-        if (decayShape->getValueUnnormalised() != curves[1].getCurve()) {
-            decayShape->setUnnormalisedValueNotifyingHost(curves[1].getCurve());
-        }
-        if (releaseShape->getValueUnnormalised() != curves[2].getCurve()) {
-            releaseShape->setUnnormalisedValueNotifyingHost(curves[2].getCurve());
-        }
+        updateIfApproxEqual(attackTime, times[0]);
+        updateIfApproxEqual(attackLevel, levels[1]);
+        updateIfApproxEqual(attackShape, curves[0].getCurve());
+        updateIfApproxEqual(decayTime, times[1]);
+        updateIfApproxEqual(sustainLevel, levels[2]);
+        updateIfApproxEqual(decayShape, curves[1].getCurve());
+        updateIfApproxEqual(releaseTime, times[2]);
+        updateIfApproxEqual(releaseShape, curves[2].getCurve());
         DBG("adsr changed");
     }
 }

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -716,7 +716,10 @@ void OscirenderAudioProcessor::envelopeChanged(EnvelopeComponent* changedEnvelop
     EnvCurveList curves = env.getCurves();
 
     if (levels.size() == 4 && times.size() == 3 && curves.size() == 3) {
-        this->adsrEnv = env;
+        {
+            juce::SpinLock::ScopedLockType lock(effectsLock);
+            this->adsrEnv = env;
+        }
         updateIfApproxEqual(attackTime, times[0]);
         updateIfApproxEqual(attackLevel, levels[1]);
         updateIfApproxEqual(attackShape, curves[0].getCurve());

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -141,6 +141,11 @@ OscirenderAudioProcessor::OscirenderAudioProcessor()
         addParameter(parameter);
     }
 
+    addParameter(attack);
+    addParameter(decay);
+    addParameter(sustain);
+    addParameter(release);
+
     for (int i = 0; i < 4; i++) {
         synth.addVoice(new ShapeVoice(*this));
     }
@@ -693,6 +698,39 @@ void OscirenderAudioProcessor::parameterValueChanged(int parameterIndex, float n
 }
 
 void OscirenderAudioProcessor::parameterGestureChanged(int parameterIndex, bool gestureIsStarting) {}
+
+void OscirenderAudioProcessor::envelopeChanged(EnvelopeComponent* changedEnvelope) {
+    Env env = changedEnvelope->getEnv();
+    std::vector<double> levels = env.getLevels();
+    std::vector<double> times = env.getTimes();
+    EnvCurveList curves = env.getCurves();
+
+    if (levels.size() == 4 && times.size() == 3 && curves.size() == 3) {
+        this->adsrEnv = env;
+        if (attack->getValueUnnormalised() != times[0]) {
+            attack->setUnnormalisedValueNotifyingHost(times[0]);
+        }
+        if (decay->getValueUnnormalised() != times[1]) {
+            decay->setUnnormalisedValueNotifyingHost(times[1]);
+        }
+        if (sustain->getValueUnnormalised() != levels[2]) {
+            sustain->setUnnormalisedValueNotifyingHost(levels[2]);
+        }
+        if (release->getValueUnnormalised() != times[2]) {
+            release->setUnnormalisedValueNotifyingHost(times[2]);
+        }
+        if (attackShape->getValueUnnormalised() != curves[0].getCurve()) {
+            attackShape->setUnnormalisedValueNotifyingHost(curves[0].getCurve());
+        }
+        if (decayShape->getValueUnnormalised() != curves[1].getCurve()) {
+            decayShape->setUnnormalisedValueNotifyingHost(curves[1].getCurve());
+        }
+        if (releaseShape->getValueUnnormalised() != curves[2].getCurve()) {
+            releaseShape->setUnnormalisedValueNotifyingHost(curves[2].getCurve());
+        }
+        DBG("adsr changed");
+    }
+}
 
 
 //==============================================================================

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -21,6 +21,7 @@
 #include "audio/WobbleEffect.h"
 #include "audio/PerspectiveEffect.h"
 #include "obj/ObjectServer.h"
+#include "UGen/Env.h"
 
 //==============================================================================
 /**
@@ -191,6 +192,8 @@ public:
     juce::ChangeBroadcaster broadcaster;
     std::atomic<bool> objectServerRendering = false;
     juce::ChangeBroadcaster fileChangeBroadcaster;
+
+    Env adsrEnv = Env::adsr(0.1, 0.1, 0.1, 0.1, 0.1);
 
 private:
     juce::SpinLock consumerLock;

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -195,20 +195,20 @@ public:
     std::atomic<bool> objectServerRendering = false;
     juce::ChangeBroadcaster fileChangeBroadcaster;
 
-    FloatParameter* attack = new FloatParameter("Attack", "attack", VERSION_HINT, 0.1, 0.0, 1.0);
+    FloatParameter* attackTime = new FloatParameter("Attack Time", "attackTime", VERSION_HINT, 0.05, 0.0, 1.0);
     FloatParameter* attackLevel = new FloatParameter("Attack Level", "attackLevel", VERSION_HINT, 1.0, 0.0, 1.0);
-    FloatParameter* decay = new FloatParameter("Decay", "decay", VERSION_HINT, 0.1, 0.0, 1.0);
-    FloatParameter* sustain = new FloatParameter("Sustain", "sustain", VERSION_HINT, 0.1, 0.0, 1.0);
-    FloatParameter* release = new FloatParameter("Release", "release", VERSION_HINT, 0.1, 0.0, 1.0);
-    FloatParameter* attackShape = new FloatParameter("Attack Shape", "attackShape", VERSION_HINT, 0.0, 0.0, 1.0);
-    FloatParameter* decayShape = new FloatParameter("Decay Shape", "decayShape", VERSION_HINT, 0.0, 0.0, 1.0);
-    FloatParameter* releaseShape = new FloatParameter("Release Shape", "releaseShape", VERSION_HINT, 0.0, 0.0, 1.0);
+    FloatParameter* decayTime = new FloatParameter("Decay Time", "decayTime", VERSION_HINT, 0.05, 0.0, 1.0);
+    FloatParameter* sustainLevel = new FloatParameter("Sustain Level", "sustainLevel", VERSION_HINT, 0.8, 0.0, 1.0);
+    FloatParameter* releaseTime = new FloatParameter("Release Time", "releaseTime", VERSION_HINT, 0.2, 0.0, 1.0);
+    FloatParameter* attackShape = new FloatParameter("Attack Shape", "attackShape", VERSION_HINT, 5, -50, 50);
+    FloatParameter* decayShape = new FloatParameter("Decay Shape", "decayShape", VERSION_HINT, -20, -50, 50);
+    FloatParameter* releaseShape = new FloatParameter("Release Shape", "releaseShape", VERSION_HINT, 5,-50, 50);
 
     Env adsrEnv = Env::adsr(
-        attack->getValueUnnormalised(),
-        decay->getValueUnnormalised(),
-        sustain->getValueUnnormalised(),
-        release->getValueUnnormalised(),
+        attackTime->getValueUnnormalised(),
+        decayTime->getValueUnnormalised(),
+        sustainLevel->getValueUnnormalised(),
+        releaseTime->getValueUnnormalised(),
         1.0,
         std::vector<EnvCurve>{ attackShape->getValueUnnormalised(), decayShape->getValueUnnormalised(), releaseShape->getValueUnnormalised() }
     );

--- a/Source/UGen/Env.cpp
+++ b/Source/UGen/Env.cpp
@@ -221,9 +221,10 @@ float Env::lookup(float time) const throw()
 	float level0 = levels_[stageIndex-1];
 	float level1 = levels_[stageIndex];
 
-	EnvCurve curve = getCurves()[stageIndex-1];
-	EnvCurve::CurveType type = curve.getType();
-	float curveValue = curve.getCurve();
+	int curveIndex = (stageIndex - 1) % curves_.size();
+
+	EnvCurve::CurveType type = curves_.data[curveIndex].getType();
+	float curveValue = curves_.data[curveIndex].getCurve();
 
 	if((lastTime - stageTime)==0.f)
 	{

--- a/Source/UGen/Env.cpp
+++ b/Source/UGen/Env.cpp
@@ -52,6 +52,48 @@ Env::Env(std::vector<double> levels,
 {
 }
 
+Env& Env::operator=(Env const& other) throw() {
+	if (this != &other) {
+        levels_ = other.levels_;
+        times_ = other.times_;
+        curves_ = other.curves_;
+        releaseNode_ = other.releaseNode_;
+        loopNode_ = other.loopNode_;
+    }
+    return *this;
+}
+
+bool Env::operator==(const Env& other) const throw() {
+	// approximate comparison
+	bool levelsEqual = true;
+	for (int i = 0; i < levels_.size(); i++) {
+        if (std::abs(levels_[i] - other.levels_[i]) > 0.001) {
+            levelsEqual = false;
+            break;
+        }
+    }
+
+	// approximate comparison
+	bool timesEqual = true;
+	for (int i = 0; i < times_.size(); i++) {
+        if (std::abs(times_[i] - other.times_[i]) > 0.001) {
+            timesEqual = false;
+            break;
+        }
+    }
+
+	// approximate comparison
+	bool curvesEqual = true;
+	for (int i = 0; i < curves_.size(); i++) {
+        if (std::abs(curves_[i].getCurve() - other.curves_[i].getCurve()) > 0.001) {
+            curvesEqual = false;
+            break;
+        }
+    }
+
+	return levelsEqual && timesEqual && curvesEqual;
+}
+
 Env::~Env() throw() {}
 
 double Env::duration() const throw() {
@@ -272,11 +314,11 @@ Env Env::adsr(const double attackTime,
 	const double sustainLevel, 
 	const double releaseTime,
 	const double level, 
-	EnvCurve const& curve) throw()
+	EnvCurveList const& curves) throw()
 {
 	return Env({ 0.0, level, (level * sustainLevel), 0.0 },
 		{ attackTime, decayTime, releaseTime },
-		curve, 2);
+		curves, 2);
 }
 
 Env Env::asr(const double attackTime, 

--- a/Source/UGen/Env.cpp
+++ b/Source/UGen/Env.cpp
@@ -1,0 +1,293 @@
+// $Id$
+// $HeadURL$
+
+/*
+==============================================================================
+
+This file is part of the UGEN++ library
+Copyright 2008-11 The University of the West of England.
+by Martin Robinson
+
+------------------------------------------------------------------------------
+
+UGEN++ can be redistributed and/or modified under the terms of the
+GNU General Public License, as published by the Free Software Foundation;
+either version 2 of the License, or (at your option) any later version.
+
+UGEN++ is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with UGEN++; if not, visit www.gnu.org/licenses or write to the
+Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+Boston, MA 02111-1307 USA
+
+The idea for this project and code in the UGen implementations is
+derived from SuperCollider which is also released under the 
+GNU General Public License:
+
+SuperCollider real time audio synthesis system
+Copyright (c) 2002 James McCartney. All rights reserved.
+http://www.audiosynth.com
+
+==============================================================================
+*/
+
+#ifndef UGEN_NOEXTGPL
+
+#include "Env.h"
+
+Env::Env(std::vector<double> levels, 
+	std::vector<double> times, 
+	EnvCurveList const& curves, 
+	const int releaseNode, 
+	const int loopNode) throw()
+	:	levels_(levels),
+	times_(times),
+	curves_(curves),
+	releaseNode_(releaseNode),
+	loopNode_(loopNode)
+{
+}
+
+Env::~Env() throw() {}
+
+double Env::duration() const throw() {
+	return std::reduce(times_.begin(), times_.end());
+}
+
+Env Env::levelScale(const double scale) const throw()
+{
+	std::vector<double> newLevels;
+	for (auto level : levels_) {
+        newLevels.push_back(level * scale);
+    }
+	return Env(newLevels,
+		times_, 
+		curves_,
+		releaseNode_,
+		loopNode_);
+}
+
+Env Env::levelBias(const double bias) const throw()
+{
+	std::vector<double> newLevels;
+	for (auto level : levels_) {
+        newLevels.push_back(level + bias);
+    }
+	return Env(newLevels,
+		times_, 
+		curves_,
+		releaseNode_,
+		loopNode_);
+}
+
+Env Env::timeScale(const double scale) const throw()
+{
+	std::vector<double> newTimes;
+    for (auto time : times_) {
+        newTimes.push_back(time * scale);
+    }
+	return Env(levels_,
+		newTimes, 
+		curves_,
+		releaseNode_,
+		loopNode_);
+}
+
+inline double linlin(const double input, 
+	const double inLow, const double inHigh,
+	const double outLow, const double outHigh) throw()
+{
+	double inRange = inHigh - inLow;
+	double outRange = outHigh - outLow;
+	return (input - inLow) * outRange / inRange + outLow;
+}
+
+inline double linexp(const double input, 
+	const double inLow, const double inHigh,
+	const double outLow, const double outHigh) throw()
+{
+	double outRatio = outHigh / outLow;
+	double reciprocalInRange = 1.0 / (inHigh - inLow);
+	double negInLowOverInRange = reciprocalInRange * -inLow;
+	return outLow * pow(outRatio, input * reciprocalInRange + negInLowOverInRange);	
+}
+
+inline double linsin(const double input, 
+	const double inLow, const double inHigh,
+	const double outLow, const double outHigh) throw()
+{
+	double inRange = inHigh - inLow;
+	double outRange = outHigh - outLow;
+
+	double inPhase = (input - inLow) * std::numbers::pi / inRange + std::numbers::pi;
+#ifndef UGEN_ANDROID
+	double cosInPhase = std::cos(inPhase) * 0.5 + 0.5;
+#else
+	double cosInPhase = cos(inPhase) * 0.5 + 0.5;
+#endif
+
+	return cosInPhase * outRange + outLow;	
+}
+
+inline float linwelch(const float input, 
+	const float inLow, const float inHigh,
+	const float outLow, const float outHigh) throw()
+{
+	float inRange = inHigh - inLow;
+	float outRange = outHigh - outLow;
+	float inPos = (input - inLow) / inRange;
+
+#ifndef UGEN_ANDROID
+	if (outLow < outHigh)
+		return outLow + outRange * std::sin(std::numbers::pi * inPos / 2);
+	else
+		return outHigh - outRange * std::sin(std::numbers::pi / 2 - std::numbers::pi * inPos / 2);
+#else
+	if (outLow < outHigh)
+		return outLow + outRange * sinf(piOverTwo * inPos);
+	else
+		return outHigh - outRange * sinf(piOverTwo - piOverTwo * inPos);	
+#endif
+}
+
+float Env::lookup(float time) const throw()
+{
+	const int numTimes = times_.size();
+	const int numLevels = levels_.size();
+	const int lastLevel = numLevels-1;
+
+	if(numLevels < 1) return 0.f;
+	if(time <= 0.f || numTimes == 0) return levels_[0];
+
+	float lastTime = 0.f;
+	float stageTime = 0.f;
+	int stageIndex = 0;
+
+	while(stageTime < time && stageIndex < numTimes)
+	{
+		lastTime = stageTime;
+		stageTime += times_[stageIndex];
+		stageIndex++;
+	}
+
+	if(stageIndex > numTimes) return levels_[lastLevel];
+
+	float level0 = levels_[stageIndex-1];
+	float level1 = levels_[stageIndex];
+
+	EnvCurve curve = getCurves()[stageIndex-1];
+	EnvCurve::CurveType type = curve.getType();
+	float curveValue = curve.getCurve();
+
+	if((lastTime - stageTime)==0.f)
+	{
+		return level1;
+	}
+	else if(type == EnvCurve::Linear)
+	{
+		return linlin(time, lastTime, stageTime, level0, level1);
+	}
+	else if(type == EnvCurve::Numerical)
+	{
+		if(abs(curveValue) <= 0.001)
+		{
+			return linlin(time, lastTime, stageTime, level0, level1);
+		}
+		else
+		{			
+			float pos = (time-lastTime) / (stageTime-lastTime);
+#ifndef UGEN_ANDROID
+			float denom = 1.f - std::exp(curveValue);
+			float numer = 1.f - std::exp(pos * curveValue);
+#else
+			// android
+			float denom = 1.f - expf(curveValue);
+			float numer = 1.f - expf(pos * curveValue);
+#endif
+			return level0 + (level1 - level0) * (numer/denom);
+		}
+	}
+	else if(type == EnvCurve::Sine)
+	{
+		return linsin(time, lastTime, stageTime, level0, level1);
+	}
+	else if(type == EnvCurve::Exponential)
+	{
+		return linexp(time, lastTime, stageTime, level0, level1);
+	}
+	else if(type == EnvCurve::Welch)
+	{
+		return linwelch(time, lastTime, stageTime, level0, level1);
+	}
+	else
+	{
+		// Empty or Step
+		return level1;
+	}
+}
+
+Env Env::linen(const double attackTime, 
+	const double sustainTime, 
+	const double releaseTime, 
+	const double sustainLevel,
+	EnvCurve const& curve) throw()
+{
+	return Env({ 0.0, sustainLevel, sustainLevel, 0.0 },
+		{ attackTime, sustainTime, releaseTime },
+		curve);
+}
+
+Env Env::triangle(const double duration,
+	const double level) throw() {
+	const double durationHalved = duration * 0.5;
+	return Env({ 0.0, level, 0.0 },
+		{ durationHalved, durationHalved });
+}
+
+Env Env::sine(const double duration, 
+	const double level) throw()
+{
+	const double durationHalved = duration * 0.5;
+	return Env({ 0.0, level, 0.0 },
+		{ durationHalved, durationHalved },
+		EnvCurve::Sine);	
+}
+
+Env Env::perc(const double attackTime, 
+	const double releaseTime, 
+	const double level, 
+	EnvCurve const& curve) throw()
+{
+	return Env({ 0.0, level, 0.0 },
+		{ attackTime, releaseTime },
+		curve);	
+}
+
+Env Env::adsr(const double attackTime, 
+	const double decayTime, 
+	const double sustainLevel, 
+	const double releaseTime,
+	const double level, 
+	EnvCurve const& curve) throw()
+{
+	return Env({ 0.0, level, (level * sustainLevel), 0.0 },
+		{ attackTime, decayTime, releaseTime },
+		curve, 2);
+}
+
+Env Env::asr(const double attackTime, 
+	const double sustainLevel, 
+	const double releaseTime, 
+	const double level, 
+	EnvCurve const& curve) throw()
+{
+	return Env({ 0.0, (level * sustainLevel), 0.0 },
+		{ attackTime, releaseTime },
+		curve, 1);
+}
+
+#endif // gpl

--- a/Source/UGen/Env.h
+++ b/Source/UGen/Env.h
@@ -84,6 +84,7 @@ public:
 
 	Env(Env const& copy) throw();
 	Env& operator= (Env const& other) throw();
+	bool operator== (const Env& other) const throw();
 
 	~Env() throw();
 
@@ -133,14 +134,14 @@ public:
 	@param sustainLevel	The level of the sustain portion as a ratio of the peak level.
 	@param releaseTime		The duration of the release portion.
 	@param level			The peak level of the envelope.
-	@param curve			The curvature of the envelope.
+	@param curves			The curves of the envelope.
 	@return				The Env envelope specification. */	
 	static Env adsr(const double attackTime = 0.01, 
 		const double decayTime = 0.3, 
 		const double sustainLevel = 0.5, 
 		const double releaseTime = 1.0, 
 		const double level = 1.0, 
-		EnvCurve const& curve = -4.0) throw();
+		EnvCurveList const& curves = -4.0) throw();
 
 	/**  Creates a new envelope specification which is shaped like traditional analog attack-sustain-release (asr) envelopes.
 	@param attackTime		The duration of the attack portion.

--- a/Source/UGen/Env.h
+++ b/Source/UGen/Env.h
@@ -1,0 +1,202 @@
+// $Id$
+// $HeadURL$
+
+/*
+==============================================================================
+
+This file is part of the UGEN++ library
+Copyright 2008-11 The University of the West of England.
+by Martin Robinson
+
+------------------------------------------------------------------------------
+
+UGEN++ can be redistributed and/or modified under the terms of the
+GNU General Public License, as published by the Free Software Foundation;
+either version 2 of the License, or (at your option) any later version.
+
+UGEN++ is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with UGEN++; if not, visit www.gnu.org/licenses or write to the
+Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+Boston, MA 02111-1307 USA
+
+The idea for this project and code in the UGen implementations is
+derived from SuperCollider which is also released under the 
+GNU General Public License:
+
+SuperCollider real time audio synthesis system
+Copyright (c) 2002 James McCartney. All rights reserved.
+http://www.audiosynth.com
+
+==============================================================================
+*/
+
+#ifndef _UGEN_ugen_Env_H_
+#define _UGEN_ugen_Env_H_
+
+#include "EnvCurve.h"
+#include <vector>
+#include <cmath>
+#include <JuceHeader.h>
+#include <numbers>
+
+
+/** A specification for a segmented envelope.
+
+An Env can have any number of segments which can stop at a particular value or 
+loop several segments when sustaining. An Env can have several shapes for its segments.
+
+An Env is usually passed as an argument to the EnvGen UGen which performs the Env, Env is 
+not UGen on its own.
+
+In the Juce version there is an graphical editor EnvelopeComponent (and a version
+with a few more features EnvelopeContainerComponent).
+
+@ingroup EnvUGens
+@see EnvGen EnvelopeContainerComponent EnvelopeComponent
+*/
+class Env
+{
+public:
+
+	/// @name Construction and destruction
+	/// @{
+
+	/**
+	Creates an Env with supplied specification.
+	*/
+	Env(std::vector<double> levels = { 0.0, 1.0, 0.0 },		/**<	A Buffer of levels. e.g. B(0.0, 1.0, 1.0, 0.0) you can also use the macro LL - List Levels. */
+		std::vector<double> times = { 1.0, 1.0 },				/**<	A Buffer of times. e.g., B(0.1, 0.8, 0.1) would have a total duration of 1sec. Macro LT - List Times can be used.
+		There should be one fewer time than level. */
+		EnvCurveList const& curves = EnvCurve(EnvCurve::Linear),	/**<	The shape of each segment. An EnvCurveList, with upto 
+		the same number of elements as the times Buffer. 
+		E.g., C(-0.5, 0.5, 0.0)*/
+		const int releaseNode = -1,							/**<	The index of the level to sustain at until released. 
+		If this is -1 the envelope will not sustain and will have a fixed duration. */
+		const int loopNode = -1								/**<	The index of the level to loop back to from the releaseNode.
+		If this is -1 the envelope will sustain at the relaseNode. */
+	) throw();
+
+
+	Env(Env const& copy) throw();
+	Env& operator= (Env const& other) throw();
+
+	~Env() throw();
+
+	/** Creates a new envelope specification which has a trapezoidal shape.
+	@param attackTime		The duration of the attack portion.
+	@param sustainTime		the duration of the sustain portion.	 
+	@param releaseTime		The duration of the release portion.
+	@param sustainLevel	The level of the sustain portion.
+	@param curve			The curvature of the envelope.
+	@return				The Env envelope specification. */
+	static Env linen(const double attackTime = 1.0, 
+		const double sustainTime = 2.0, 
+		const double releaseTime = 1.0, 
+		const double sustainLevel = 1.0,
+		EnvCurve const& curve = EnvCurve::Linear) throw();
+
+	/**  Creates a new envelope specification which has a triangle shape.
+	@param duration	The duration of the envelope.
+	@param level		The peak level of the envelope.
+	@return			The Env envelope specification. */
+	static Env triangle(const double duration = 1.0, 
+		const double level = 1.0) throw();
+
+	/**  Creates a new envelope specification which has a hanning window shape.
+	@param duration	The duration of the envelope.
+	@param level		The peak level of the envelope.
+	@return			The Env envelope specification. */	
+	static Env sine(const double duration = 1.0, 
+		const double level = 1.0) throw();
+
+	/**  Creates a new envelope specification which (usually) has a percussive shape.
+
+	@param attackTime	The duration of the attack portion.
+	@param releaseTime The duration of the release portion.
+	@param level		The peak level of the envelope.
+	@param curve		The curvature of the envelope.
+	@return			The Env envelope specification. */	
+	static Env perc(const double attackTime = 0.01, 
+		const double releaseTime = 1.0, 
+		const double level = 1.0, 
+		EnvCurve const& curve = -4.0) throw();
+
+	/**  Creates a new envelope specification which is shaped like traditional analog attack-decay-sustain-release (adsr) envelopes.
+
+	@param attackTime		The duration of the attack portion.
+	@param decayTime		The duration of the decay portion.
+	@param sustainLevel	The level of the sustain portion as a ratio of the peak level.
+	@param releaseTime		The duration of the release portion.
+	@param level			The peak level of the envelope.
+	@param curve			The curvature of the envelope.
+	@return				The Env envelope specification. */	
+	static Env adsr(const double attackTime = 0.01, 
+		const double decayTime = 0.3, 
+		const double sustainLevel = 0.5, 
+		const double releaseTime = 1.0, 
+		const double level = 1.0, 
+		EnvCurve const& curve = -4.0) throw();
+
+	/**  Creates a new envelope specification which is shaped like traditional analog attack-sustain-release (asr) envelopes.
+	@param attackTime		The duration of the attack portion.
+	@param sustainLevel	The level of the sustain portion as a ratio of the peak level.
+	@param releaseTime		The duration of the release portion.
+	@param level			The peak level of the envelope.
+	@param curve			The curvature of the envelope.
+	@return				The Env envelope specification. */		
+	static Env asr(const double attackTime = 0.01, 
+		const double sustainLevel = 1.0, 
+		const double releaseTime = 1.0, 
+		const double level = 1.0, 
+		EnvCurve const& curve = -4.0) throw();
+
+	/// @} <!-- end Construction and destruction ------------------------------------------- -->
+
+	/// @name Envelope access and manipulation
+	/// @{
+
+	inline std::vector<double>			getTimes() const throw()	{ return times_;	}
+	inline std::vector<double>			getLevels() const throw()	{ return levels_; }
+	inline EnvCurveList	getCurves() const throw()	{ return curves_; }
+
+	inline int getReleaseNode() const throw()	{ return releaseNode_;	}
+	inline int getLoopNode() const throw()		{ return loopNode_;		}
+
+	/** Returns the sum the time values in the envelope. */
+	double duration() const throw();
+
+	/** Returns a new envelope with the levels scaled by a constant. */
+	Env levelScale(const double scale) const throw();
+
+	/** Returns a new envelope with the levels offset by a constant. */
+	Env levelBias(const double bias) const throw();
+
+	/** Returns a new envelope with the time values scaled by a constant. */
+	Env timeScale(const double scale) const throw();
+
+	/** Get the level of the Env a ta given time.
+	This ignores loopNode and releaseNode if the are set. */
+	float lookup(float time) const throw();
+
+	/** Write the Env into an exisiting Buffer.
+	This fits the Env into whatever size the Buffer is.
+	This ignores loopNode and releaseNode if the are set. */
+	void writeToBuffer(std::vector<double>& buffer, const int channel = 0) const throw();
+
+	/// @} <!-- end Envelope access and manipulation ----------------------------- -->
+
+private:
+	std::vector<double> levels_;
+	std::vector<double> times_;
+	EnvCurveList curves_;
+	int releaseNode_;
+	int loopNode_;
+};
+
+
+#endif // _UGEN_ugen_Env_H_

--- a/Source/UGen/EnvCurve.cpp
+++ b/Source/UGen/EnvCurve.cpp
@@ -69,6 +69,10 @@ EnvCurveList& EnvCurveList::operator= (EnvCurveList const& other) throw()
 	return *this;
 }
 
+bool EnvCurveList::operator==(EnvCurveList const& other) const throw() {
+	return data == other.data;
+}
+
 EnvCurve& EnvCurveList::operator[] (const int index) throw() {
 	return data[index % size()];
 }

--- a/Source/UGen/EnvCurve.cpp
+++ b/Source/UGen/EnvCurve.cpp
@@ -1,0 +1,132 @@
+// $Id$
+// $HeadURL$
+
+/*
+==============================================================================
+
+This file is part of the UGEN++ library
+Copyright 2008-11 The University of the West of England.
+by Martin Robinson
+
+------------------------------------------------------------------------------
+
+UGEN++ can be redistributed and/or modified under the terms of the
+GNU General Public License, as published by the Free Software Foundation;
+either version 2 of the License, or (at your option) any later version.
+
+UGEN++ is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with UGEN++; if not, visit www.gnu.org/licenses or write to the
+Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+Boston, MA 02111-1307 USA
+
+The idea for this project and code in the UGen implementations is
+derived from SuperCollider which is also released under the 
+GNU General Public License:
+
+SuperCollider real time audio synthesis system
+Copyright (c) 2002 James McCartney. All rights reserved.
+http://www.audiosynth.com
+
+==============================================================================
+*/
+
+#include "EnvCurve.h"
+
+EnvCurveList::EnvCurveList(EnvCurve const& i00) throw() {
+	data.push_back(i00);
+}
+
+EnvCurveList::EnvCurveList(std::vector<EnvCurve> curves) throw() {
+	data = curves;
+}
+
+EnvCurveList::EnvCurveList(EnvCurve::CurveType type, const int size) throw(){
+	for(int i = 0; i < size; i++)
+		data.push_back(EnvCurve(type));
+}
+
+EnvCurveList::EnvCurveList(const double curve, const int size) throw()
+{
+	for(int i = 0; i < size; i++)
+		data.push_back(EnvCurve(curve));
+}
+
+EnvCurveList::~EnvCurveList() throw() {}
+
+EnvCurveList::EnvCurveList(EnvCurveList const& copy) throw() : data(copy.data) {}
+
+EnvCurveList& EnvCurveList::operator= (EnvCurveList const& other) throw()
+{
+	if (this != &other) {		
+		data = other.data;
+	}
+
+	return *this;
+}
+
+EnvCurve& EnvCurveList::operator[] (const int index) throw() {
+	return data[index % size()];
+}
+
+const EnvCurve& EnvCurveList::operator[] (const int index) const throw() {
+	return data[index % size()];
+}
+
+EnvCurveList EnvCurveList::blend(EnvCurveList const& other, float fraction) const throw() {
+	const int maxSize = juce::jmax(size(), other.size());
+	const int minSize = juce::jmin(size(), other.size());
+	fraction = juce::jmax(0.f, fraction);
+	fraction = juce::jmin(1.f, fraction);
+
+	EnvCurveList newList(0.0, maxSize);
+
+	for(int i = 0; i < minSize; i++)
+	{
+		EnvCurve thisCurve = data[i];
+		EnvCurve otherCurve = other.data[i];
+
+		if((thisCurve.getType() == EnvCurve::Numerical) && (otherCurve.getType() == EnvCurve::Numerical))
+		{
+			float thisValue = thisCurve.getCurve();
+			float otherValue = otherCurve.getCurve();
+			float newValue = thisValue * (1.f-fraction) + otherValue * fraction;
+			newList.data[i] = EnvCurve(newValue);
+		}
+		else
+		{
+			if(fraction < 0.5f)
+				newList.data[i] = thisCurve;
+			else
+				newList.data[i] = otherCurve;
+		}
+	}
+
+	// should really turn this loop "inside out" save doing the if() for each iteration
+	for(int i = minSize; i < maxSize; i++)
+	{
+		EnvCurve thisCurve = data[i];
+		EnvCurve otherCurve = other.data[i];
+
+		if(size() < other.size())
+		{
+			if(fraction < 0.5f)
+				newList.data[i] = EnvCurve(EnvCurve::Linear);
+			else
+				newList.data[i] = otherCurve;
+		}
+		else
+		{
+			if(fraction < 0.5f)
+				newList.data[i] = thisCurve;
+			else
+				newList.data[i] = EnvCurve(EnvCurve::Linear);
+		}
+	}
+
+	return newList;
+}

--- a/Source/UGen/EnvCurve.h
+++ b/Source/UGen/EnvCurve.h
@@ -121,6 +121,7 @@ public:
 
 	EnvCurveList(EnvCurveList const& copy) throw();
 	EnvCurveList& operator= (EnvCurveList const& other) throw();
+	bool operator== (EnvCurveList const& other) const throw();
 
 
 	/// @} <!-- end Construction and destruction ------------------------------------------- -->

--- a/Source/UGen/EnvCurve.h
+++ b/Source/UGen/EnvCurve.h
@@ -140,7 +140,6 @@ public:
 
 	/// @} <!-- end Array access and manipulation ----------------------------------------------- -->
 
-private:
 	static EnvCurve empty;
 	std::vector<EnvCurve> data;
 };

--- a/Source/UGen/EnvCurve.h
+++ b/Source/UGen/EnvCurve.h
@@ -1,0 +1,148 @@
+// $Id$
+// $HeadURL$
+
+/*
+==============================================================================
+
+This file is part of the UGEN++ library
+Copyright 2008-11 The University of the West of England.
+by Martin Robinson
+
+------------------------------------------------------------------------------
+
+UGEN++ can be redistributed and/or modified under the terms of the
+GNU General Public License, as published by the Free Software Foundation;
+either version 2 of the License, or (at your option) any later version.
+
+UGEN++ is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with UGEN++; if not, visit www.gnu.org/licenses or write to the
+Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+Boston, MA 02111-1307 USA
+
+The idea for this project and code in the UGen implementations is
+derived from SuperCollider which is also released under the 
+GNU General Public License:
+
+SuperCollider real time audio synthesis system
+Copyright (c) 2002 James McCartney. All rights reserved.
+http://www.audiosynth.com
+
+==============================================================================
+*/
+
+#ifndef _UGEN_ugen_EnvCurve_H_
+#define _UGEN_ugen_EnvCurve_H_
+
+#include <vector>
+#include <JuceHeader.h>
+
+/** Specify curved sections of breakpoint envelopes.
+Curve type may be linear or from a selection of curve types, or a numerical
+value which specifies the degree of curvature.
+
+@see Env, EnvGen */
+class EnvCurve
+{
+public:
+
+	/// @name Construction and destruction
+	/// @{
+
+	enum CurveType
+	{
+		Empty,
+		Numerical,
+		Step,
+		Linear,
+		Exponential,
+		Sine,
+		Welch
+	};
+
+	EnvCurve(float curve) throw()				: type_(Numerical), curve_(curve)			{ }
+	//EnvCurve(double curve) throw()				: type_(Numerical), curve_((float)curve)	{ }
+	EnvCurve(CurveType type = Empty) throw()	: type_(type), curve_(0.f)					{ }
+
+	/// @} <!-- end Construction and destruction ------------------------------------------- -->
+
+	/// @name Curve access
+	/// @{
+
+	CurveType getType() const throw()				{ return type_;	 }
+	float getCurve() const throw()					{ return curve_; }
+	void setType(const CurveType newType) throw()	{ type_ = newType;	 }
+	void setCurve(const float newCurve) throw()		{ curve_ = newCurve; }
+
+	bool equalsInfinity() const throw()	{ return type_ == Numerical && curve_ == INFINITY; }
+
+	bool operator==(EnvCurve const& other) const
+	{
+		if (type_ != other.type_)
+			return false;
+
+		if (type_ == Numerical)
+			return curve_ == other.curve_;
+
+		return true;
+	}
+
+	bool operator!=(EnvCurve const& other) const { return !(*this==other); }
+
+
+	/// @} <!-- end Curve access ----------------------------------------------------------- -->
+
+private:
+	CurveType type_;
+	float curve_;	
+};
+
+/** An array of EnvCurve objects.
+
+@see EnvCurve, Env, EnvGen */
+class EnvCurveList
+{
+public:
+
+	/// @name Construction and destruction
+	/// @{
+
+	EnvCurveList(EnvCurve const& i00) throw();
+	EnvCurveList(std::vector<EnvCurve>) throw();
+
+	EnvCurveList(EnvCurve::CurveType type, const int size = 1) throw();
+	EnvCurveList(const double curve, const int size = 1) throw();
+
+	~EnvCurveList() throw();
+
+	EnvCurveList(EnvCurveList const& copy) throw();
+	EnvCurveList& operator= (EnvCurveList const& other) throw();
+
+
+	/// @} <!-- end Construction and destruction ------------------------------------------- -->
+
+	/// @name Array access and manipulation
+	/// @{
+
+	EnvCurve& operator[] (const int index) throw();
+	const EnvCurve& operator[] (const int index) const throw();
+
+	inline int size() const throw()									{ return data.size();		}
+	inline const std::vector<EnvCurve> const getData() throw()					{ return data;		}
+	inline const std::vector<EnvCurve> const getData() const throw()			{ return data;		}
+
+	EnvCurveList blend(EnvCurveList const& other, float fraction) const throw();
+
+	/// @} <!-- end Array access and manipulation ----------------------------------------------- -->
+
+private:
+	static EnvCurve empty;
+	std::vector<EnvCurve> data;
+};
+
+
+#endif // _UGEN_ugen_EnvCurve_H_

--- a/Source/UGen/ugen_JuceEnvelopeComponent.cpp
+++ b/Source/UGen/ugen_JuceEnvelopeComponent.cpp
@@ -470,7 +470,6 @@ void EnvelopeHandleComponent::setTimeAndValue(double timeToSet, double valueToSe
 	dontUpdateTimeAndValue = oldDontUpdateTimeAndValue;
 	
 	getParentComponent()->repaint();
-	getParentComponent()->sendChangeMessage();
 }
 
 void EnvelopeHandleComponent::offsetTimeAndValue(double offsetTime, double offsetValue, double quantise)
@@ -493,7 +492,7 @@ double EnvelopeHandleComponent::constrainDomain(double domainToConstrain) const
 	if(previousHandle != 0) left += FINETUNE;
 	if(nextHandle != 0) right -= FINETUNE;
 		
-	return juce::jlimit(left, right, shouldLockTime ? time : domainToConstrain);
+	return juce::jlimit(juce::jmin(left, right), juce::jmax(left, right), shouldLockTime ? time : domainToConstrain);
 }
 
 double EnvelopeHandleComponent::constrainValue(double valueToConstrain) const
@@ -1274,8 +1273,9 @@ void EnvelopeComponent::setEnv(Env const& env)
 		for (int i = 0; i < handles.size(); i++) {
 			EnvelopeHandleComponent* handle = handles.getUnchecked(i);
             handle->setTimeAndValue(time, (double)levels[i], 0.0);
-            handle->setCurve(curves[i]);
-			quantiseHandle(handle);
+			if (i > 0) {
+				handle->curve = curves[i - 1];
+			}
 			if (i < times.size()) {
 				time += times[i];
 			}

--- a/Source/UGen/ugen_JuceEnvelopeComponent.cpp
+++ b/Source/UGen/ugen_JuceEnvelopeComponent.cpp
@@ -1,0 +1,1805 @@
+// $Id$
+// $HeadURL$
+
+/*
+ ==============================================================================
+ 
+ This file is part of the UGEN++ library
+ Copyright 2008-11 The University of the West of England.
+ by Martin Robinson
+ 
+ ------------------------------------------------------------------------------
+ 
+ UGEN++ can be redistributed and/or modified under the terms of the
+ GNU General Public License, as published by the Free Software Foundation;
+ either version 2 of the License, or (at your option) any later version.
+ 
+ UGEN++ is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with UGEN++; if not, visit www.gnu.org/licenses or write to the
+ Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ Boston, MA 02111-1307 USA
+ 
+ The idea for this project and code in the UGen implementations is
+ derived from SuperCollider which is also released under the 
+ GNU General Public License:
+ 
+ SuperCollider real time audio synthesis system
+ Copyright (c) 2002 James McCartney. All rights reserved.
+ http://www.audiosynth.com
+ 
+ ==============================================================================
+ */
+
+#ifndef UGEN_NOEXTGPL
+
+#include "ugen_JuceEnvelopeComponent.h"
+
+
+EnvelopeHandleComponentConstrainer::EnvelopeHandleComponentConstrainer(EnvelopeHandleComponent* handleOwner)
+	:	leftLimit(0),
+		rightLimit(0xffffff),
+		handle(handleOwner)
+{
+}
+
+void EnvelopeHandleComponentConstrainer::checkBounds (juce::Rectangle<int>& bounds,
+					  const juce::Rectangle<int>& old, const juce::Rectangle<int>& limits,
+					  bool isStretchingTop, bool isStretchingLeft,
+					  bool isStretchingBottom, bool isStretchingRight)
+{
+	
+	ComponentBoundsConstrainer::checkBounds(bounds,
+											old,limits,
+											isStretchingTop,isStretchingLeft,
+											isStretchingBottom,isStretchingRight);
+	
+	// prevent this handle moving before the previous point
+	// or after the next point	
+	bounds.setPosition(juce::jlimit(leftLimit, rightLimit, bounds.getX()), bounds.getY());
+	
+	
+	// then use the handle to access the envelope to then quantise x+y..
+	
+//	EnvelopeComponent* env = handle->getParentComponent();
+//	
+//	if(env)
+//	{
+//		double domain = env->convertPixelsToDomain(bounds.getX());
+//		double value = env->convertPixelsToValue(bounds.getY());
+//		
+//		domain = env->quantiseDomain(domain);
+//		value = env->quantiseValue(value);
+//		
+//		bounds.setPosition(env->convertDomainToPixels(domain), 
+//						   env->convertValueToPixels(value));
+//	}
+}
+
+
+void EnvelopeHandleComponentConstrainer::setAdjacentHandleLimits(int setLeftLimit, int setRightLimit)
+{
+	leftLimit = setLeftLimit;
+	rightLimit = setRightLimit;
+}
+
+EnvelopeHandleComponent::EnvelopeHandleComponent()
+	:	dontUpdateTimeAndValue(false),
+		lastX(-1),
+		lastY(-1),
+		resizeLimits(this),
+        shouldLockTime(false),
+        shouldLockValue(false),
+		ignoreDrag(false)
+{
+	setMouseCursor(juce::MouseCursor::CrosshairCursor);
+	resetOffsets();
+}
+
+EnvelopeComponent* EnvelopeHandleComponent::getParentComponent() const
+{
+	return (EnvelopeComponent*)Component::getParentComponent();
+}
+
+void EnvelopeHandleComponent::updateTimeAndValue()
+{
+    if (shouldLockTime)
+    {
+        setTopLeftPosition(getParentComponent()->convertDomainToPixels(time),
+                           getY());
+    }
+    else time = getParentComponent()->convertPixelsToDomain(getX());
+    
+    if (shouldLockValue)
+    {
+        setTopLeftPosition(getX(),
+                           getParentComponent()->convertValueToPixels(value));
+    }
+    else value = getParentComponent()->convertPixelsToValue(getY());
+	
+#ifdef MYDEBUG
+	printf("MyEnvelopeHandleComponent::updateTimeAndValue(%f, %f)\n", time, value);
+#endif
+}
+
+void EnvelopeHandleComponent::updateLegend()
+{	
+	EnvelopeComponent *env = getParentComponent();
+	EnvelopeLegendComponent* legend = env->getLegend();
+
+	if(legend == 0) return;
+
+	juce::String text;
+	
+	int width = getParentWidth();
+	int places;
+	
+	if(width >= 165) {
+		
+		if(env && env->isLoopNode(this))
+			text << "(Loop) ";
+		else if(env && env->isReleaseNode(this))
+			text << "(Release) ";
+		else
+			text << "Point ";
+		
+		places = 3;
+	}
+	else if(width >= 140) {
+		text << "Point ";
+		places = 3;
+	} else if(width >= 115) {
+		text << "Pt ";
+		places = 3;
+	} else if(width >= 100) {
+		text << "Pt ";
+		places = 2;
+	} else if(width >= 85) {
+		text << "Pt ";
+		places = 1;
+	} else if(width >= 65) {
+		text << "P ";
+		places = 1;
+	} else {
+		places = 1;
+	}
+	
+	text << (getHandleIndex())
+		 << ": "
+		 << juce::String(legend->mapTime(time), places) << legend->getTimeUnits()
+		 << ", "
+		 << juce::String(legend->mapValue(value), places) << legend->getValueUnits();
+	
+	getParentComponent()->setLegendText(text);
+}
+
+void EnvelopeHandleComponent::paint(juce::Graphics& g)
+{
+	EnvelopeComponent *env = getParentComponent();
+	juce::Colour handleColour;
+	
+	if(env == 0)
+	{
+		handleColour = juce::Colour(0xFF69B4FF);
+	}
+	else if(env->isReleaseNode(this))
+	{
+		handleColour = env->getEnvColour(EnvelopeComponent::ReleaseNode);
+	}
+	else if(env->isLoopNode(this))
+	{
+		handleColour = env->getEnvColour(EnvelopeComponent::LoopNode);
+	}
+	else
+	{
+		handleColour = env->getEnvColour(EnvelopeComponent::Node);
+	}
+	
+	g.setColour(handleColour);
+	g.fillRect(1, 1, getWidth()-2, getHeight()-2);
+}
+
+void EnvelopeHandleComponent::moved()
+{
+	if(dontUpdateTimeAndValue == false)
+		updateTimeAndValue();
+}
+
+void EnvelopeHandleComponent::mouseMove(const juce::MouseEvent& e)
+{
+	(void)e;
+#ifdef MYDEBUG
+	printf("MyEnvelopeHandleComponent::mouseMove\n");
+#endif
+}
+
+void EnvelopeHandleComponent::mouseEnter(const juce::MouseEvent& e)
+{
+	(void)e;
+#ifdef MYDEBUG
+	printf("MyEnvelopeHandleComponent::mouseEnter\n");
+#endif
+	
+	setMouseCursor(juce::MouseCursor::CrosshairCursor);	
+	updateLegend();
+}
+
+void EnvelopeHandleComponent::mouseExit(const juce::MouseEvent& e)
+{
+	(void)e;
+#ifdef MYDEBUG
+	printf("MyEnvelopeHandleComponent::mouseExit\n");
+#endif
+	
+	getParentComponent()->setLegendTextToDefault();
+}
+
+void EnvelopeHandleComponent::mouseDown(const juce::MouseEvent& e)
+{
+#ifdef MYDEBUG
+	printf("MyEnvelopeHandleComponent::mouseDown (%d, %d)\n", e.x, e.y);
+#endif
+	
+	setMouseCursor(juce::MouseCursor::NoCursor);
+	
+	if(e.mods.isShiftDown()) {
+		
+        if(!shouldLockTime && !shouldLockValue)
+        {
+            getParentComponent()->setLegendTextToDefault();
+            removeThisHandle();
+		}
+        
+        return; // dont send drag msg
+		
+	} 
+	else if(e.mods.isCtrlDown())
+	{
+		if(getParentComponent()->getAllowNodeEditing())
+		{
+			ignoreDrag = true;
+			
+			if(PopupComponent::getActivePopups() < 1)
+			{
+				EnvelopeNodePopup::create(this, getScreenX()+e.x, getScreenY()+e.y);
+			}
+		}
+	}
+	else 
+	{
+		
+		offsetX = e.x;
+		offsetY = e.y;
+		
+		resizeLimits.setMinimumOnscreenAmounts(HANDLESIZE,HANDLESIZE,HANDLESIZE,HANDLESIZE);
+		
+		EnvelopeHandleComponent* previousHandle = getPreviousHandle();
+		EnvelopeHandleComponent* nextHandle = getNextHandle();
+		
+		int leftLimit = previousHandle == 0 ? 0 : previousHandle->getX()+2;
+		int rightLimit = nextHandle == 0 ? getParentWidth()-HANDLESIZE : nextHandle->getX()-2;
+//		int leftLimit = previousHandle == 0 ? 0 : previousHandle->getX();
+//		int rightLimit = nextHandle == 0 ? getParentWidth()-HANDLESIZE : nextHandle->getX();
+
+		
+		resizeLimits.setAdjacentHandleLimits(leftLimit, rightLimit);
+
+		dragger.startDraggingComponent(this, e);//&resizeLimits);
+	
+	}
+    
+    getParentComponent()->sendStartDrag();
+}
+
+void EnvelopeHandleComponent::mouseDrag(const juce::MouseEvent& e)
+{
+	if(ignoreDrag == true) return;
+	
+	if(e.mods.isAltDown()) {
+
+		int moveX = e.x-offsetX;
+		int moveY = offsetY-e.y;
+		
+		offsetTimeAndValue(moveX * FINETUNE, moveY * FINETUNE, FINETUNE);
+		ignoreDrag = true;
+		setMousePositionToThisHandle();
+		ignoreDrag = false;
+		
+	} else {
+				
+		dragger.dragComponent(this, e, &resizeLimits);
+	}
+	
+	updateLegend();
+	getParentComponent()->repaint();
+	getParentComponent()->sendChangeMessage();
+	
+	if(lastX == getX() && lastY == getY()) {	
+		setMousePositionToThisHandle();
+#ifdef MYDEBUG
+		int x, y;
+		Desktop::getMousePosition(x, y);	
+		printf("screen pos (and mouse pos): %d (%d) %d (%d)\n", getScreenX(), x, getScreenY(), y);
+#endif	
+	}
+
+	lastX = getX();
+	lastY = getY();
+	
+#ifdef MYDEBUG
+	double domain = getParentComponent()->convertPixelsToDomain(getX());
+	double value = getParentComponent()->convertPixelsToValue(getY());
+	printf("MyEnvelopeHandleComponent::mouseDrag(%d, %d) [%f, %f] (%d, %d)\n", e.x, e.y, 
+		   domain,
+		   value,
+		   getParentComponent()->convertDomainToPixels(domain),
+		   getParentComponent()->convertValueToPixels(value));
+#endif
+	
+}
+
+
+void EnvelopeHandleComponent::mouseUp(const juce::MouseEvent& e)
+{
+	(void)e;
+    EnvelopeComponent *env = getParentComponent();
+
+#ifdef MYDEBUG
+	printf("MyEnvelopeHandleComponent::mouseUp\n");
+#endif
+	
+	if(ignoreDrag == true)
+	{
+		ignoreDrag = false;
+		goto exit;
+	}
+		
+//	if(e.mods.isCtrlDown() == false)
+//	{
+		env->quantiseHandle(this);
+//	}
+	
+	setMouseCursor(juce::MouseCursor::CrosshairCursor);
+	setMousePositionToThisHandle();
+	
+	offsetX = 0;
+	offsetY = 0;
+    
+exit:
+    getParentComponent()->sendEndDrag();
+}
+
+
+EnvelopeHandleComponent* EnvelopeHandleComponent::getPreviousHandle() const
+{
+	return getParentComponent()->getPreviousHandle(this);
+}
+
+EnvelopeHandleComponent* EnvelopeHandleComponent::getNextHandle() const
+{
+	return getParentComponent()->getNextHandle(this);
+}
+
+void EnvelopeHandleComponent::removeThisHandle()
+{
+	getParentComponent()->removeHandle(this);
+}
+
+void EnvelopeHandleComponent::setMousePositionToThisHandle()
+{
+	juce::Desktop::setMousePosition(juce::Point<int>(getScreenX()+offsetX, getScreenY()+offsetY));
+}
+
+int EnvelopeHandleComponent::getHandleIndex() const
+{
+	return getParentComponent()->getHandleIndex(const_cast<EnvelopeHandleComponent*>(this));
+}
+
+void EnvelopeHandleComponent::setTime(double timeToSet)
+{
+	bool oldDontUpdateTimeAndValue = dontUpdateTimeAndValue;
+	dontUpdateTimeAndValue = true;
+	
+	time = constrainDomain(timeToSet);
+	
+	setTopLeftPosition(getParentComponent()->convertDomainToPixels(time), 
+					   getY());
+	
+	dontUpdateTimeAndValue = oldDontUpdateTimeAndValue;
+	
+	getParentComponent()->repaint();
+	((EnvelopeComponent*)getParentComponent())->sendChangeMessage();
+}
+
+void EnvelopeHandleComponent::setValue(double valueToSet)
+{
+	bool oldDontUpdateTimeAndValue = dontUpdateTimeAndValue;
+	dontUpdateTimeAndValue = true;
+	
+	value = constrainValue(valueToSet);
+	
+	setTopLeftPosition(getX(), 
+					   getParentComponent()->convertValueToPixels(value));
+	
+	dontUpdateTimeAndValue = oldDontUpdateTimeAndValue;
+	
+	getParentComponent()->repaint();
+	((EnvelopeComponent*)getParentComponent())->sendChangeMessage();
+}
+
+void EnvelopeHandleComponent::setCurve(EnvCurve curveToSet)
+{
+	curve = curveToSet;
+	getParentComponent()->repaint();
+	((EnvelopeComponent*)getParentComponent())->sendChangeMessage();
+}
+
+void EnvelopeHandleComponent::setTimeAndValue(double timeToSet, double valueToSet, double quantise)
+{
+	bool oldDontUpdateTimeAndValue = dontUpdateTimeAndValue;
+	dontUpdateTimeAndValue = true;
+
+#ifdef MYDEBUG
+	printf("MyEnvelopeHandleComponent::setTimeAndValue original (%f, %f)\n", timeToSet, valueToSet);
+#endif
+	
+	if(quantise > 0.0) {
+		int steps;
+
+		steps		= valueToSet / quantise;
+		valueToSet	= steps * quantise;
+		steps		= timeToSet  / quantise;
+		timeToSet	= steps * quantise;
+		
+#ifdef MYDEBUG
+		printf("MyEnvelopeHandleComponent::setTimeAndValue quantised (%f, %f)\n", timeToSet, valueToSet);
+#endif
+	}
+	
+//	valueToSet = getParentComponent()->quantiseValue(valueToSet);
+//	timeToSet = getParentComponent()->quantiseDomain(timeToSet);
+	
+	value = constrainValue(valueToSet);
+	time = constrainDomain(timeToSet);
+	
+	setTopLeftPosition(getParentComponent()->convertDomainToPixels(time), 
+					   getParentComponent()->convertValueToPixels(value));
+	
+	dontUpdateTimeAndValue = oldDontUpdateTimeAndValue;
+	
+	getParentComponent()->repaint();
+	getParentComponent()->sendChangeMessage();
+}
+
+void EnvelopeHandleComponent::offsetTimeAndValue(double offsetTime, double offsetValue, double quantise)
+{
+	setTimeAndValue(time+offsetTime, value+offsetValue, quantise);
+}
+
+
+double EnvelopeHandleComponent::constrainDomain(double domainToConstrain) const
+{ 
+	EnvelopeHandleComponent* previousHandle = getPreviousHandle();
+	EnvelopeHandleComponent* nextHandle = getNextHandle();
+
+	int leftLimit = previousHandle == 0 ? 0 : previousHandle->getX();
+	int rightLimit = nextHandle == 0 ? getParentWidth()-HANDLESIZE : nextHandle->getX();
+	
+	double left = getParentComponent()->convertPixelsToDomain(leftLimit);
+	double right = getParentComponent()->convertPixelsToDomain(rightLimit);
+	
+	if(previousHandle != 0) left += FINETUNE;
+	if(nextHandle != 0) right -= FINETUNE;
+		
+	return juce::jlimit(left, right, shouldLockTime ? time : domainToConstrain);
+}
+
+double EnvelopeHandleComponent::constrainValue(double valueToConstrain) const
+{
+	return getParentComponent()->constrainValue(shouldLockValue ? value : valueToConstrain);
+}
+
+void EnvelopeHandleComponent::lockTime(double timeToLock)
+{
+    setTime(timeToLock);
+    shouldLockTime = true;
+}
+
+void EnvelopeHandleComponent::lockValue(double valueToLock)
+{
+    setValue(valueToLock);
+    shouldLockValue = true;
+}
+
+void EnvelopeHandleComponent::unlockTime()
+{
+    shouldLockTime = false;
+}
+
+void EnvelopeHandleComponent::unlockValue()
+{
+    shouldLockValue = false;
+}
+
+void EnvelopeHandleComponent::recalculatePosition()
+{
+	bool oldDontUpdateTimeAndValue = dontUpdateTimeAndValue;
+	dontUpdateTimeAndValue = true;
+	setTopLeftPosition(getParentComponent()->convertDomainToPixels(time), 
+					   getParentComponent()->convertValueToPixels(value));
+	dontUpdateTimeAndValue = oldDontUpdateTimeAndValue;
+	getParentComponent()->repaint();
+}
+
+
+EnvelopeComponent::EnvelopeComponent()
+:	minNumHandles(0),
+	maxNumHandles(0xffffff),
+	domainMin(0.0),
+	domainMax(1.0),
+	valueMin(0.0),
+	valueMax(1.0),
+	valueGrid((valueMax-valueMin) / 10),
+	domainGrid((domainMax-domainMin) / 16),
+	gridDisplayMode(GridNone),
+	gridQuantiseMode(GridNone),
+	draggingHandle(0),
+	curvePoints(64),
+	releaseNode(-1),
+	loopNode(-1),
+	allowCurveEditing(true),
+	allowNodeEditing(true)
+{
+	setMouseCursor(juce::MouseCursor::NormalCursor);
+	setBounds(0, 0, 200, 200); // non-zero size to start with
+		
+	colours[Node]				= juce::Colour(0xFF69B4FF);
+	colours[ReleaseNode]		= juce::Colour(0xFFB469FF);
+	colours[LoopNode]			= juce::Colour(0xFF69FFB4);
+	colours[Line]				= juce::Colour(0xFFFFFFFF);
+	colours[LoopLine]			= juce::Colour(0xFFB469FF);
+	colours[Background]			= juce::Colour(0xFF555555);
+	colours[GridLine]			= juce::Colour(0xFF888888);
+	colours[LegendText]			= juce::Colour(0xFF000000);
+	colours[LegendBackground]	= juce::Colour(0xFF696969);
+}
+
+EnvelopeComponent::~EnvelopeComponent()
+{
+	deleteAllChildren();
+}
+
+void EnvelopeComponent::setDomainRange(const double min, const double max)
+{
+	bool changed = false;
+	
+	if(domainMin != min)
+	{
+		changed = true;
+		domainMin = min;
+	}
+	
+	if(domainMax != max)
+	{
+		changed = true;
+		domainMax = max;
+	}
+	
+	if(changed == true)
+	{
+		recalculateHandles();
+	}
+}
+
+void EnvelopeComponent::getDomainRange(double& min, double& max) const
+{
+	min = domainMin;
+	max = domainMax;
+}
+
+void EnvelopeComponent::setValueRange(const double min, const double max)
+{
+	bool changed = false;
+	
+	if(valueMin != min)
+	{
+		changed = true;
+		valueMin = min;
+	}
+	
+	if(valueMax != max)
+	{
+		changed = true;
+		valueMax = max;
+	}
+	
+	if(changed == true)
+	{
+		recalculateHandles();
+	}	
+}
+
+void EnvelopeComponent::getValueRange(double& min, double& max) const
+{
+	min = valueMin;
+	max = valueMax;
+}
+
+void EnvelopeComponent::recalculateHandles()
+{
+	for(int i = 0; i < handles.size(); i++) 
+	{
+		handles.getUnchecked(i)->recalculatePosition();
+	}
+}
+
+void EnvelopeComponent::setGrid(const GridMode display, const GridMode quantise, const double domainQ, const double valueQ)
+{
+	if(quantise != GridLeaveUnchanged)
+		gridQuantiseMode = quantise;
+	
+	if((display != GridLeaveUnchanged) && (display != gridDisplayMode))
+	{
+		gridDisplayMode = display;
+		repaint();
+	}
+	
+	if((domainQ > 0.0) && (domainQ != domainGrid))
+	{
+		domainGrid = domainQ;
+		repaint();
+	}
+	
+	if((valueQ > 0.0) && (valueQ != valueGrid))
+	{
+		valueGrid = valueQ;
+		repaint();
+	}
+}
+
+void EnvelopeComponent::getGrid(GridMode& display, GridMode& quantise, double& domainQ, double& valueQ) const
+{
+	display = gridDisplayMode;
+	quantise = gridQuantiseMode;
+	domainQ = domainGrid;
+	valueQ = valueGrid;
+}
+
+void EnvelopeComponent::paint(juce::Graphics& g)
+{
+	paintBackground(g);
+	
+	if(handles.size() > 0)
+	{
+		juce::Path path;
+		Env env = getEnv();
+		
+		EnvelopeHandleComponent* handle = handles.getUnchecked(0);
+		path.startNewSubPath((handle->getX() + handle->getRight()) * 0.5f,
+							 (handle->getY() + handle->getBottom()) * 0.5f);
+		
+		const float firstTime = handle->getTime();
+		float time = firstTime;
+		
+		for(int i = 1; i < handles.size(); i++) 
+		{
+			handle = handles.getUnchecked(i);
+			float halfWidth = handle->getWidth()*0.5f;
+			float halfHeight = handle->getHeight()*0.5f;
+			
+			float nextTime = handle->getTime();
+			float handleTime = nextTime - time;
+			float timeInc = handleTime / curvePoints;
+			
+			for(int j = 0; j < curvePoints; j++)
+			{
+				float value = env.lookup(time - firstTime);
+				path.lineTo(convertDomainToPixels(time) + halfWidth, 
+							convertValueToPixels(value) + halfHeight);
+				time += timeInc;
+			}
+			
+			path.lineTo((handle->getX() + handle->getRight()) * 0.5f,
+						(handle->getY() + handle->getBottom()) * 0.5f);
+			
+			time = nextTime;
+		}
+		
+		g.setColour(colours[Line]);
+		g.strokePath (path, juce::PathStrokeType(1.0f));
+		
+		if((loopNode >= 0) && (releaseNode >= 0) && (releaseNode > loopNode))
+		{			
+			EnvelopeHandleComponent* releaseHandle = handles[releaseNode];
+			EnvelopeHandleComponent* loopHandle = handles[loopNode];
+			
+			if((releaseHandle != 0) && (loopHandle != 0))
+			{
+				// draw a horizontal line from release
+				g.setColour(colours[LoopLine]);
+				
+				const float loopY = (loopHandle->getY() + loopHandle->getBottom()) * 0.5f;
+				const float releaseY = (releaseHandle->getY() + releaseHandle->getBottom()) * 0.5f;
+				const float loopX = (loopHandle->getX() + loopHandle->getRight()) * 0.5f;
+				const float releaseX = (releaseHandle->getX() + releaseHandle->getRight()) * 0.5f;
+				
+				float dashes[] = { 5, 3 };
+				juce::Line<float> line(loopX, releaseY, loopX, loopY);
+				g.drawDashedLine(line, dashes, 2, 0.5f);
+				
+				const int arrowLength = HANDLESIZE*2;
+				
+				g.drawLine(releaseX, releaseY, 
+						   loopX + arrowLength, releaseY, 
+						   0.5f);
+				
+				if(loopY == releaseY)
+					g.setColour(colours[LoopNode]);
+				
+//				g.drawArrow(loopX + arrowLength, releaseY, 
+//							loopX, releaseY, 
+//							0.5f, HANDLESIZE, arrowLength);
+				g.drawArrow(juce::Line<float>((float)(loopX + arrowLength), releaseY, loopX, releaseY), 
+							0.5f, HANDLESIZE, arrowLength);
+				
+			}
+		}
+	}
+}
+
+inline double round(double a, double b) throw()
+{
+	double offset = a < 0 ? -0.5 : 0.5;
+	int n = (int)(a / b + offset);
+	return b * (double)n;
+}
+
+void EnvelopeComponent::paintBackground(juce::Graphics& g)
+{
+	g.setColour(colours[Background]);
+	g.fillRect(0, 0, getWidth(), getHeight());
+	
+	g.setColour(colours[GridLine]);
+	
+	if((gridDisplayMode & GridValue) && (valueGrid > 0.0))
+	{
+		double value = valueMin;
+		
+		while(value <= valueMax)
+		{
+			//g.drawHorizontalLine(convertValueToPixels(value) + HANDLESIZE/2, 0, getWidth());
+			float y = convertValueToPixels(value) + HANDLESIZE/2;
+			y = round(y, 1.f) + 0.5f;
+			g.drawLine(0, y, getWidth(), y, 1.0f);
+			value += valueGrid;
+		}
+	}
+	
+	if((gridDisplayMode & GridDomain) && (domainGrid > 0.0))
+	{
+		double domain = domainMin;
+		
+		while(domain <= domainMax)
+		{
+			g.drawVerticalLine(convertDomainToPixels(domain) + HANDLESIZE/2, 0, getHeight());
+			domain += domainGrid;
+		}
+	}
+}
+
+void EnvelopeComponent::resized()
+{	
+#ifdef MYDEBUG
+	printf("MyEnvelopeComponent::resized(%d, %d)\n", getWidth(), getHeight());
+#endif
+	if(handles.size() != 0) {
+		for(int i = 0; i < handles.size(); i++) {
+			EnvelopeHandleComponent* handle = handles.getUnchecked(i);
+			
+			bool oldDontUpdateTimeAndValue = handle->dontUpdateTimeAndValue;
+			handle->dontUpdateTimeAndValue = true;
+						
+			handle->setTopLeftPosition(convertDomainToPixels(handle->getTime()),
+									   convertValueToPixels(handle->getValue()));
+			
+			handle->dontUpdateTimeAndValue = oldDontUpdateTimeAndValue;
+		}
+	}	
+}
+
+
+void EnvelopeComponent::mouseEnter(const juce::MouseEvent& e) 
+{
+	(void)e;
+	setMouseCursor(juce::MouseCursor::NormalCursor);
+}
+
+void EnvelopeComponent::mouseMove(const juce::MouseEvent& e) 
+{
+	(void)e;
+	setMouseCursor(juce::MouseCursor::NormalCursor);
+}
+
+void EnvelopeComponent::mouseDown(const juce::MouseEvent& e)
+{
+#ifdef MYDEBUG
+	printf("MyEnvelopeComponent::mouseDown(%d, %d)\n", e.x, e.y);
+#endif
+	
+	if(e.mods.isShiftDown()) 
+	{
+		
+		// not needed ?
+				
+	}
+	else if(e.mods.isCtrlDown())
+	{
+		if(getAllowCurveEditing())
+		{
+			float timeAtClick = convertPixelsToDomain(e.x);
+			
+			int i;
+			EnvelopeHandleComponent* handle = 0;
+			
+			for(i = 0; i < handles.size(); i++) {
+				handle = handles.getUnchecked(i);
+				if(handle->getTime() > timeAtClick)
+					break;
+			}
+			
+			if(PopupComponent::getActivePopups() < 1)
+			{
+				EnvelopeHandleComponent* prev = handle->getPreviousHandle();
+				
+				if(!prev)
+				{
+					EnvelopeCurvePopup::create(handle, getScreenX()+e.x, getScreenY()+e.y);
+				}
+				else
+				{
+					EnvelopeCurvePopup::create(handle, 
+											   (handle->getScreenX() + prev->getScreenX())/2, 
+						juce::jmax(handle->getScreenY(), prev->getScreenY())+10);
+				}
+			}
+		}
+	}
+	else 
+	{
+		draggingHandle = addHandle(e.x,e.y, EnvCurve::Linear);
+		
+		if(draggingHandle != 0) {
+			setMouseCursor(juce::MouseCursor::NoCursor);
+			draggingHandle->mouseDown(e.getEventRelativeTo(draggingHandle));
+			draggingHandle->updateLegend();
+		}
+	}
+}
+
+void EnvelopeComponent::mouseDrag(const juce::MouseEvent& e)
+{
+#ifdef MYDEBUG
+	printf("MyEnvelopeComponent::mouseDrag(%d, %d)\n", e.x, e.y);
+#endif
+		
+	if(draggingHandle != 0)
+		draggingHandle->mouseDrag(e.getEventRelativeTo(draggingHandle));
+}
+
+void EnvelopeComponent::mouseUp(const juce::MouseEvent& e)
+{
+#ifdef MYDEBUG
+	printf("MyEnvelopeComponent::mouseUp\n");
+#endif
+	
+	if(draggingHandle != 0) 
+	{
+		if(e.mods.isCtrlDown() == false)
+			quantiseHandle(draggingHandle);
+		
+		setMouseCursor(juce::MouseCursor::CrosshairCursor);
+		draggingHandle->setMousePositionToThisHandle();
+		draggingHandle->resetOffsets();
+		draggingHandle = 0;
+        sendEndDrag();
+	} else {
+		setMouseCursor(juce::MouseCursor::NormalCursor);
+	}
+}
+
+void EnvelopeComponent::addListener (EnvelopeComponentListener* const listener)
+{
+	if (listener != 0)
+        listeners.add (listener);
+}
+
+void EnvelopeComponent::removeListener (EnvelopeComponentListener* const listener)
+{
+	listeners.removeValue(listener);
+}
+
+void EnvelopeComponent::sendChangeMessage()
+{
+	for (int i = listeners.size(); --i >= 0;)
+    {
+        ((EnvelopeComponentListener*) listeners.getUnchecked (i))->envelopeChanged (this);
+        i = juce::jmin (i, listeners.size());
+    }
+}
+
+void EnvelopeComponent::sendStartDrag()
+{
+    for (int i = listeners.size(); --i >= 0;)
+    {
+        ((EnvelopeComponentListener*) listeners.getUnchecked (i))->envelopeStartDrag (this);
+        i = juce::jmin (i, listeners.size());
+    }
+}
+
+void EnvelopeComponent::sendEndDrag()
+{
+    for (int i = listeners.size(); --i >= 0;)
+    {
+        ((EnvelopeComponentListener*) listeners.getUnchecked (i))->envelopeEndDrag (this);
+        i = juce::jmin (i, listeners.size());
+    }
+}
+
+void EnvelopeComponent::clear()
+{
+    int i = getNumHandles();
+    
+    while (i > 0)
+        removeHandle(handles[--i]);
+}
+
+EnvelopeLegendComponent* EnvelopeComponent::getLegend()
+{
+	EnvelopeContainerComponent* container = 
+	dynamic_cast <EnvelopeContainerComponent*> (getParentComponent());
+	
+	if(container == 0) return 0;
+	
+	return container->getLegendComponent();
+}
+
+void EnvelopeComponent::setLegendText(juce::String legendText)
+{	
+	EnvelopeLegendComponent* legend = getLegend();
+	
+	if(legend == 0) return;
+	
+	legend->setText(legendText);
+}
+
+void EnvelopeComponent::setLegendTextToDefault()
+{
+	EnvelopeLegendComponent* legend = getLegend();
+	
+	if(legend == 0) return;
+	
+	legend->setText();	
+}
+
+int EnvelopeComponent::getHandleIndex(EnvelopeHandleComponent* thisHandle) const
+{
+	return handles.indexOf(thisHandle);
+}
+
+EnvelopeHandleComponent* EnvelopeComponent::getHandle(const int index) const
+{
+	return handles[index];
+}
+
+EnvelopeHandleComponent* EnvelopeComponent::getPreviousHandle(const EnvelopeHandleComponent* thisHandle) const
+{
+	int thisHandleIndex = handles.indexOf(const_cast<EnvelopeHandleComponent*>(thisHandle));
+	
+	if(thisHandleIndex <= 0) 
+		return 0;
+	else 
+		return handles.getUnchecked(thisHandleIndex-1);
+}
+
+EnvelopeHandleComponent* EnvelopeComponent::getNextHandle(const EnvelopeHandleComponent* thisHandle) const
+{
+	int thisHandleIndex = handles.indexOf(const_cast<EnvelopeHandleComponent*>(thisHandle));
+	
+	if(thisHandleIndex == -1 || thisHandleIndex >= handles.size()-1) 
+		return 0;
+	else
+		return handles.getUnchecked(thisHandleIndex+1);
+}
+
+
+EnvelopeHandleComponent* EnvelopeComponent::addHandle(int newX, int newY, EnvCurve curve)
+{
+#ifdef MYDEBUG
+	printf("MyEnvelopeComponent::addHandle(%d, %d)\n", newX, newY);
+#endif
+	
+	return addHandle(convertPixelsToDomain(newX), convertPixelsToValue(newY), curve);
+}
+
+
+EnvelopeHandleComponent* EnvelopeComponent::addHandle(double newDomain, double newValue, EnvCurve curve)
+{
+#ifdef MYDEBUG
+	printf("MyEnvelopeComponent::addHandle(%f, %f)\n", (float)newDomain, (float)newValue);
+#endif
+	
+//	newDomain = quantiseDomain(newDomain);
+//	newValue = quantiseValue(newValue);
+	
+	if(handles.size() < maxNumHandles) {
+		int i;
+		for(i = 0; i < handles.size(); i++) {
+			EnvelopeHandleComponent* handle = handles.getUnchecked(i);
+			if(handle->getTime() > newDomain)
+				break;
+		}
+		
+		if(releaseNode >= i) releaseNode++;
+		if(loopNode >= i) loopNode++;
+		
+		EnvelopeHandleComponent* handle;
+		addAndMakeVisible(handle = new EnvelopeHandleComponent());
+		handle->setSize(HANDLESIZE, HANDLESIZE);
+		handle->setTimeAndValue(newDomain, newValue, 0.0);	
+		handle->setCurve(curve);
+		handles.insert(i, handle);
+	//	sendChangeMessage();
+		return handle;
+	}
+	else return 0;
+}
+
+
+void EnvelopeComponent::removeHandle(EnvelopeHandleComponent* thisHandle)
+{
+	if(handles.size() > minNumHandles) {
+		int index = handles.indexOf(thisHandle);
+		
+		if(releaseNode >= 0)
+		{
+			if(releaseNode == index)
+				releaseNode = -1;
+			else if(releaseNode > index)
+				releaseNode--;
+		}
+		
+		if(loopNode >= 0)
+		{
+			if(loopNode == index)
+				loopNode = -1;
+			else if(loopNode > index)
+				loopNode--;
+		}
+		
+		handles.removeFirstMatchingValue(thisHandle);
+		removeChildComponent(thisHandle);
+		delete thisHandle;
+		sendChangeMessage();
+		repaint();
+	}
+}
+
+void EnvelopeComponent::quantiseHandle(EnvelopeHandleComponent* thisHandle)
+{
+	if((gridQuantiseMode & GridDomain) && (domainGrid > 0.0))
+	{
+		double domain = round(thisHandle->getTime(), domainGrid);
+		thisHandle->setTime(domain);
+		
+	}
+	
+	if((gridQuantiseMode & GridValue) && (valueGrid > 0.0))
+	{
+		double value = round(thisHandle->getValue(), valueGrid);
+		thisHandle->setValue(value);
+	}
+}
+
+bool EnvelopeComponent::isReleaseNode(EnvelopeHandleComponent* thisHandle) const
+{
+	int index = handles.indexOf(thisHandle);
+	
+	if(index < 0) 
+		return false;
+	else
+		return index == releaseNode;
+}
+
+bool EnvelopeComponent::isLoopNode(EnvelopeHandleComponent* thisHandle) const
+{
+	int index = handles.indexOf(thisHandle);
+	
+	if(index < 0) 
+		return false;
+	else
+		return index == loopNode;	
+}
+
+void EnvelopeComponent::setReleaseNode(const int index)
+{
+	if((index >= -1) && index < handles.size())
+	{
+		releaseNode = index;
+		repaint();
+	}
+}
+
+int EnvelopeComponent::getReleaseNode() const
+{
+	return releaseNode;
+}
+
+void EnvelopeComponent::setLoopNode(const int index)
+{
+	if((index >= -1) && index < handles.size())
+	{
+		loopNode = index;
+		repaint();
+	}
+}
+
+int EnvelopeComponent::getLoopNode() const
+{
+	return loopNode;
+}
+
+void EnvelopeComponent::setAllowCurveEditing(const bool flag)
+{
+	allowCurveEditing = flag;
+}
+
+bool EnvelopeComponent::getAllowCurveEditing() const
+{
+	return allowCurveEditing;
+}
+
+void EnvelopeComponent::setAllowNodeEditing(const bool flag)
+{
+	allowNodeEditing = flag;
+}
+
+bool EnvelopeComponent::getAllowNodeEditing() const
+{
+	return allowNodeEditing;
+}
+
+void EnvelopeComponent::setReleaseNode(EnvelopeHandleComponent* thisHandle)
+{
+	setReleaseNode(handles.indexOf(thisHandle));
+}
+
+void EnvelopeComponent::setLoopNode(EnvelopeHandleComponent* thisHandle)
+{
+	setLoopNode(handles.indexOf(thisHandle));
+}
+
+double EnvelopeComponent::convertPixelsToDomain(int pixelsX, int pixelsXMax) const
+{
+	if(pixelsXMax < 0) 
+		pixelsXMax = getWidth()-HANDLESIZE;
+	
+	return (double)pixelsX / pixelsXMax * (domainMax-domainMin) + domainMin;
+
+}
+
+double EnvelopeComponent::convertPixelsToValue(int pixelsY, int pixelsYMax) const
+{
+	if(pixelsYMax < 0)
+		pixelsYMax = getHeight()-HANDLESIZE;
+	
+	return (double)(pixelsYMax - pixelsY) / pixelsYMax * (valueMax-valueMin) + valueMin;
+}
+
+double EnvelopeComponent::convertDomainToPixels(double domainValue) const
+{
+	return (domainValue - domainMin) / (domainMax - domainMin) * (getWidth() - HANDLESIZE);
+}
+
+double EnvelopeComponent::convertValueToPixels(double value) const
+{	
+	double pixelsYMax = getHeight()-HANDLESIZE;	
+	return pixelsYMax-((value- valueMin) / (valueMax - valueMin) * pixelsYMax);
+}
+
+Env EnvelopeComponent::getEnv() const
+{
+	if (handles.size() < 1) return Env({ 0.0, 0.0 }, { 0.0 });
+	if (handles.size() < 2) return Env({ 0.0, 0.0 }, { handles.getUnchecked(0)->getValue() });
+	
+	EnvelopeHandleComponent* startHandle = handles.getUnchecked(0);
+	double currentLevel = startHandle->getValue();
+	double currentTime = startHandle->getTime();
+	
+	std::vector<double> levels(handles.size(), 0.0);
+	std::vector<double> times(handles.size() - 1, 0.0);
+	EnvCurveList curves = EnvCurveList(EnvCurve::Empty, handles.size()-1);
+	
+	levels[0] = currentLevel;
+	
+	for(int i = 1; i < handles.size(); i++) 
+	{
+		EnvelopeHandleComponent* handle = handles.getUnchecked(i);
+		
+		currentLevel = handle->getValue();
+		double time = handle->getTime();
+		
+		levels[i] = currentLevel;
+		times[i-1] = time-currentTime;
+		curves[i-1] = handle->getCurve();
+		
+		currentTime = time;
+	}
+	
+	return Env(levels, times, curves, releaseNode, loopNode);
+}
+
+void EnvelopeComponent::setEnv(Env const& env)
+{
+    clear();
+    
+    double time = 0.0;
+	
+	std::vector<double> levels = env.getLevels();
+	std::vector<double> times = env.getTimes();
+	const EnvCurveList& curves = env.getCurves();
+	
+	EnvelopeHandleComponent* handle = addHandle(time, (double)levels[0], EnvCurve::Linear);
+	quantiseHandle(handle);
+
+	for(int i = 0; i < times.size(); i++)
+	{
+		time += times[i];
+		handle = addHandle(time, (double)levels[i+1], curves[i]);
+		quantiseHandle(handle);
+	}
+	
+	releaseNode = env.getReleaseNode();
+	loopNode = env.getLoopNode();
+}
+
+float EnvelopeComponent::lookup(const float time) const
+{
+	if(handles.size() < 1)
+	{
+		return 0.f;
+	}
+	else 
+	{
+		EnvelopeHandleComponent *first = handles.getUnchecked(0);
+		EnvelopeHandleComponent *last = handles.getUnchecked(handles.size()-1);
+		
+		if(time <= first->getTime())
+		{
+			return first->getValue();
+		}
+		else if(time >= last->getTime())
+		{
+			return last->getValue();
+		}
+		else
+		{
+			return getEnv().lookup(time - first->getTime());
+		}
+	}
+}
+
+void EnvelopeComponent::setMinMaxNumHandles(int min, int max)
+{
+	if(min <= max) {
+		minNumHandles = min;
+		maxNumHandles = max;
+	} else {
+		minNumHandles = max;
+		maxNumHandles = min;
+	}
+	
+	juce::Random rand(juce::Time::currentTimeMillis());
+	
+	if(handles.size() < minNumHandles) {
+		int num = minNumHandles-handles.size();
+		
+		for(int i = 0; i < num; i++) {
+			double randX = rand.nextDouble() * (domainMax-domainMin) + domainMin;
+			double randY = rand.nextDouble() * (valueMax-valueMin) + valueMin;
+						
+			addHandle(randX, randY, EnvCurve::Linear);
+		}
+		
+	} else if(handles.size() > maxNumHandles) {
+		int num = handles.size()-maxNumHandles;
+		
+		for(int i = 0; i < num; i++) {
+			removeHandle(handles.getLast());
+		}
+	}
+	
+}
+
+double EnvelopeComponent::constrainDomain(double domainToConstrain) const
+{
+	return juce::jlimit(domainMin, domainMax, domainToConstrain); 
+}
+
+double EnvelopeComponent::constrainValue(double valueToConstrain) const	
+{ 
+	return juce::jlimit(valueMin, valueMax, valueToConstrain); 
+}
+
+
+//double EnvelopeComponent::quantiseDomain(double value)
+//{
+//	if((gridQuantiseMode & GridDomain) && (domainGrid > 0.0))
+//		return round(value, domainGrid);
+//	else
+//		return value;
+//}
+//
+//double EnvelopeComponent::quantiseValue(double value)
+//{
+//	if((gridQuantiseMode & GridValue) && (valueGrid > 0.0))
+//		return round(value, valueGrid);
+//	else
+//		return value;
+//}
+
+void EnvelopeComponent::setEnvColour(const EnvColours which, juce::Colour colour) throw()
+{
+	if((which >= 0) && (which < NumEnvColours))
+	{
+		//lock();
+		colours[which] = colour;
+		//unlock();
+		
+		//updateGUI();
+		getParentComponent()->repaint();
+		repaint();
+	}
+}
+
+const juce::Colour EnvelopeComponent::getEnvColour(const EnvColours which) const throw()
+{
+	if ((which < 0) || (which >= NumEnvColours))
+		return juce::Colour();
+	else
+		return colours[which];	
+}
+
+EnvelopeLegendComponent::EnvelopeLegendComponent(juce::String _defaultText)
+:	defaultText(_defaultText)
+{
+	addAndMakeVisible(text = new juce::Label("legend", defaultText));
+	setBounds(0, 0, 100, 16); // the critical thing is the height which should stay constant
+}
+
+EnvelopeLegendComponent::~EnvelopeLegendComponent()
+{
+	deleteAllChildren();
+}
+
+EnvelopeComponent* EnvelopeLegendComponent::getEnvelopeComponent() const
+{
+	EnvelopeContainerComponent* parent = dynamic_cast<EnvelopeContainerComponent*> (getParentComponent());
+	
+	if(parent == 0) return 0;
+	
+	return parent->getEnvelopeComponent();
+}
+
+void EnvelopeLegendComponent::resized()
+{
+	text->setBounds(0, 0, getWidth(), getHeight());
+}
+
+void EnvelopeLegendComponent::paint(juce::Graphics& g)
+{
+	EnvelopeComponent *env = getEnvelopeComponent();
+	juce::Colour backColour = env ? env->getEnvColour(EnvelopeComponent::LegendBackground) : juce::Colour(0xFF696969);
+	
+	g.setColour(backColour);
+	g.fillRect(0, 0, getWidth(), getHeight());
+	
+	juce::Colour textColour = env ? env->getEnvColour(EnvelopeComponent::LegendText) : juce::Colour(0xFF0000);
+	text->setColour(juce::Label::textColourId, textColour);
+}
+
+void EnvelopeLegendComponent::setText(juce::String legendText)
+{
+	text->setText(legendText, juce::dontSendNotification);
+	repaint();
+}
+
+void EnvelopeLegendComponent::setText()
+{
+	text->setText(defaultText, juce::dontSendNotification);
+	repaint();
+}
+
+double EnvelopeLegendComponent::mapValue(double value)
+{
+	return value;
+}
+
+double EnvelopeLegendComponent::mapTime(double time)
+{
+	return time;
+}
+
+EnvelopeContainerComponent::EnvelopeContainerComponent(juce::String defaultText)
+{
+	addAndMakeVisible(legend = new EnvelopeLegendComponent(defaultText));
+	addAndMakeVisible(envelope = new EnvelopeComponent());
+}
+
+EnvelopeContainerComponent::~EnvelopeContainerComponent()
+{
+	deleteAllChildren();
+}
+
+void EnvelopeContainerComponent::resized()
+{
+	int legendHeight = legend->getHeight();
+	
+	envelope->setBounds(0, 
+						0, 
+						getWidth(), 
+						getHeight()-legendHeight);
+	
+	legend->setBounds(0, 
+					  getHeight()-legendHeight, 
+					  getWidth(), 
+					  legend->getHeight());
+}
+
+void EnvelopeContainerComponent::setLegendComponent(EnvelopeLegendComponent* newLegend)
+{
+	deleteAndZero(legend);
+	addAndMakeVisible(legend = newLegend);
+}
+
+EnvelopeCurvePopup::EnvelopeCurvePopup(EnvelopeHandleComponent* handleToEdit)
+:	handle(handleToEdit),
+	initialised(false)
+{
+	resetCounter();
+	
+	EnvCurve curve = handle->getCurve();
+	EnvCurve::CurveType type = curve.getType();
+	float curveValue = curve.getCurve();
+	
+	addChildComponent(slider = new CurveSlider());
+	slider->setSliderStyle(juce::Slider::LinearBar);
+	//slider->setTextBoxStyle(Slider::NoTextBox, false, 0,0);
+	slider->setRange(-1, 1, 0.0);
+    
+    slider->setValue(curveValue, juce::dontSendNotification);
+	
+	
+	addAndMakeVisible(combo = new juce::ComboBox("combo"));	
+	combo->addItem("Empty",			idOffset + (int)EnvCurve::Empty);
+	combo->addItem("Numerical...",	idOffset + (int)EnvCurve::Numerical);
+	combo->addItem("Step",			idOffset + (int)EnvCurve::Step);
+	combo->addItem("Linear",		idOffset + (int)EnvCurve::Linear);
+	
+	EnvelopeComponent *parent = handleToEdit->getParentComponent();
+	double min, max;
+	parent->getValueRange(min, max);
+	
+	if(((min > 0.0) && (max > 0.0)) || ((min < 0.0) && (min < 0.0)))
+	{
+		// exponential can't cross zero
+		combo->addItem("Exponential",	idOffset + (int)EnvCurve::Exponential);
+	}
+	
+	combo->addItem("Sine",			idOffset + (int)EnvCurve::Sine);
+	combo->addItem("Welch",			idOffset + (int)EnvCurve::Welch);
+	
+	combo->addListener(this);
+	
+	switch(type)
+	{
+		case EnvCurve::Empty:		combo->setSelectedId(idOffset + (int)EnvCurve::Empty,		juce::dontSendNotification); break;
+		case EnvCurve::Numerical:	combo->setSelectedId(idOffset + (int)EnvCurve::Numerical,	juce::dontSendNotification); break;
+		case EnvCurve::Step:		combo->setSelectedId(idOffset + (int)EnvCurve::Step,		juce::dontSendNotification); break;
+		case EnvCurve::Linear:		combo->setSelectedId(idOffset + (int)EnvCurve::Linear,		juce::dontSendNotification); break;
+		case EnvCurve::Exponential: combo->setSelectedId(idOffset + (int)EnvCurve::Exponential, juce::dontSendNotification); break;
+		case EnvCurve::Sine:		combo->setSelectedId(idOffset + (int)EnvCurve::Sine,		juce::dontSendNotification); break;
+		case EnvCurve::Welch:		combo->setSelectedId(idOffset + (int)EnvCurve::Welch,		juce::dontSendNotification); break;
+	}
+	
+	slider->addListener(this);
+}
+
+void EnvelopeCurvePopup::create(EnvelopeHandleComponent* handle, int x, int y)
+{
+	EnvelopeCurvePopup *popup = new EnvelopeCurvePopup(handle);
+	popup->addToDesktop(juce::ComponentPeer::windowIsTemporary);
+	
+	if(x > 20) x -= 20;
+	//if(y > 20) y -= 20;
+	
+	const int w = 200;
+	const int h = 50;
+	const int r = x+w;
+	const int b = y+h;
+	
+	juce::Rectangle<int> monitorArea = popup->getParentMonitorArea();
+	
+	if(r > monitorArea.getRight())
+		x = monitorArea.getRight() - w;
+		
+	if(b > monitorArea.getBottom())
+		y = monitorArea.getBottom() - h;
+		
+	popup->setBounds(x, y, w, h);
+	popup->setVisible(true);		
+	popup->getPeer()->setAlwaysOnTop(true);	
+}
+
+EnvelopeCurvePopup::~EnvelopeCurvePopup()
+{
+	deleteAllChildren();
+}
+
+void EnvelopeCurvePopup::resized()
+{
+	combo->setBoundsRelative(0.05f, 0.1f, 0.9f, 0.4f);
+	slider->setBoundsRelative(0.05f, 0.50f, 0.9f, 0.4f);
+}
+
+inline double linlin(const double input, 
+	const double inLow, const double inHigh,
+	const double outLow, const double outHigh) throw()
+{
+	double inRange = inHigh - inLow;
+	double outRange = outHigh - outLow;
+	return (input - inLow) * outRange / inRange + outLow;
+}
+
+void EnvelopeCurvePopup::sliderValueChanged(juce::Slider* sliderThatChanged)
+{
+	resetCounter();
+	
+	if(sliderThatChanged == slider)
+	{
+		EnvCurve curve = handle->getCurve();
+		double value = slider->getValue();
+		value = value * value * value;
+		value = linlin(value, -1.0, 1.0, -50.0, 50.0);
+		curve.setCurve(value);
+		handle->setCurve(curve);
+	}
+}
+
+void EnvelopeCurvePopup::comboBoxChanged (juce::ComboBox* comboBoxThatHasChanged)
+{
+	resetCounter();
+	
+	if(comboBoxThatHasChanged == combo)
+	{
+		EnvCurve::CurveType type = (EnvCurve::CurveType)(combo->getSelectedId() - idOffset);
+		bool showSlider = type == EnvCurve::Numerical;
+		slider->setVisible(showSlider);
+		
+		EnvCurve curve = handle->getCurve();
+		curve.setType(type);
+		handle->setCurve(curve);
+		
+		if(!showSlider && initialised) expire();
+		
+		initialised = true;
+	}
+}
+
+void EnvelopeCurvePopup::expired()
+{
+    handle->getParentComponent()->sendEndDrag();
+}
+
+const int EnvelopeCurvePopup::idOffset = 1000;
+
+
+EnvelopeNodePopup::EnvelopeNodePopup(EnvelopeHandleComponent* handleToEdit)
+:	handle(handleToEdit),
+	initialised(false)
+{
+	resetCounter();
+	
+	addChildComponent(setLoopButton = new juce::TextButton("Set Y to Loop"));
+	addChildComponent(setReleaseButton = new juce::TextButton("Set Y to Release"));
+	setLoopButton->addListener(this);
+	setReleaseButton->addListener(this);
+	
+	addAndMakeVisible(combo = new juce::ComboBox("combo"));
+	combo->addItem("Normal",            idOffset + (int)Normal);
+	combo->addItem("Release",           idOffset + (int)Release);
+	combo->addItem("Loop",              idOffset + (int)Loop);
+	combo->addItem("Release & Loop",	idOffset + (int)ReleaseAndLoop);
+	combo->addListener(this);
+	
+	EnvelopeComponent* env = handle->getParentComponent();
+	
+	if(env != 0)
+	{
+		if(env->isLoopNode(handle) && env->isReleaseNode(handle))
+			combo->setSelectedId(idOffset + (int)ReleaseAndLoop, false);
+		else if(env->isLoopNode(handle))
+			combo->setSelectedId(idOffset + (int)Loop, false);
+		else if(env->isReleaseNode(handle))
+			combo->setSelectedId(idOffset + (int)Release, false);
+		else
+			combo->setSelectedId(idOffset + (int)Normal, false);
+	}
+	
+}
+
+void EnvelopeNodePopup::create(EnvelopeHandleComponent* handle, int x, int y)
+{
+	EnvelopeNodePopup *popup = new EnvelopeNodePopup(handle);
+	popup->addToDesktop(juce::ComponentPeer::windowIsTemporary);
+	
+	if(x > 20) x -= 20;
+	if(y > 20) y -= 20;
+	
+	const int w = 200;
+	const int h = 50;
+	const int r = x+w;
+	const int b = y+h;
+	
+	juce::Rectangle<int> monitorArea = popup->getParentMonitorArea();
+	
+	if(r > monitorArea.getRight())
+		x = monitorArea.getRight() - w;
+	
+	if(b > monitorArea.getBottom())
+		y = monitorArea.getBottom() - h;
+	
+	popup->setBounds(x, y, w, h);
+	popup->setVisible(true);		
+	popup->getPeer()->setAlwaysOnTop(true);	
+}
+
+EnvelopeNodePopup::~EnvelopeNodePopup()
+{
+	deleteAllChildren();
+}
+
+void EnvelopeNodePopup::resized()
+{
+	combo->setBoundsRelative(0.05f, 0.1f, 0.9f, 0.4f);
+	
+	// the same pos but we should see only one at a time
+	setLoopButton->setBoundsRelative(0.05f, 0.50f, 0.9f, 0.4f);
+	setReleaseButton->setBoundsRelative(0.05f, 0.50f, 0.9f, 0.4f);
+}
+
+void EnvelopeNodePopup::comboBoxChanged (juce::ComboBox* comboBoxThatHasChanged)
+{
+	resetCounter();
+	
+	if(comboBoxThatHasChanged == combo)
+	{
+		EnvelopeComponent* env = handle->getParentComponent();
+		
+		if(env != 0)
+		{
+			NodeType type = (NodeType)(combo->getSelectedId() - idOffset);
+			
+			switch(type)
+			{
+				case Normal: {
+					
+					if(env->isLoopNode(handle)) 
+						env->setLoopNode(-1);
+					
+					if(env->isReleaseNode(handle)) 
+						env->setReleaseNode(-1);
+					
+					setLoopButton->setVisible(false);
+					setReleaseButton->setVisible(false);
+					
+				} break;
+					
+				case Release: {
+					
+					if(env->isLoopNode(handle)) 
+						env->setLoopNode(-1);
+					
+					env->setReleaseNode(handle);
+					
+					setReleaseButton->setVisible(false);
+					
+					if(env->getLoopNode() != -1)
+						setLoopButton->setVisible(true);
+					
+				} break;
+					
+				case Loop: {
+					
+					env->setLoopNode(handle);
+					
+					if(env->isReleaseNode(handle)) 
+						env->setReleaseNode(-1);
+					
+					if(env->getReleaseNode() != -1)
+						setReleaseButton->setVisible(true);
+					
+					setLoopButton->setVisible(false);
+					
+				} break;
+					
+				case ReleaseAndLoop: {
+					
+					env->setLoopNode(handle);
+					env->setReleaseNode(handle);
+					
+					setLoopButton->setVisible(false);
+					setReleaseButton->setVisible(false);
+					
+				}
+			}
+		}
+		
+		if(initialised) expire();
+		
+		initialised = true;
+	}
+}
+
+void EnvelopeNodePopup::buttonClicked(juce::Button *button)
+{
+	EnvelopeComponent* env = handle->getParentComponent();
+	
+	if(env != 0)
+	{
+		if(button == setLoopButton)
+		{
+			int loopNode = env->getLoopNode();
+			
+			if(loopNode >= 0)
+			{
+				EnvelopeHandleComponent *loopHandle = env->getHandle(loopNode);
+				
+				if(loopHandle != 0)
+				{
+					float value = loopHandle->getValue();
+					handle->setValue(value);
+					expire();
+				}
+			}
+		}
+		else if(button == setReleaseButton)
+		{
+			int releaseNode = env->getReleaseNode();
+			
+			if(releaseNode >= 0)
+			{
+				EnvelopeHandleComponent *releaseHandle = env->getHandle(releaseNode);
+				
+				if(releaseHandle != 0)
+				{
+					float value = releaseHandle->getValue();
+					handle->setValue(value);
+					expire();
+				}
+			}
+			
+		}
+	}
+}
+
+void EnvelopeNodePopup::expired()
+{
+}
+
+const int EnvelopeNodePopup::idOffset = 2000;
+
+#endif // gpl

--- a/Source/UGen/ugen_JuceEnvelopeComponent.h
+++ b/Source/UGen/ugen_JuceEnvelopeComponent.h
@@ -240,6 +240,7 @@ public:
 	
 private:
 	void recalculateHandles();
+	EnvelopeHandleComponent* findHandle(double time);
 	
 	juce::SortedSet <void*> listeners;
 	juce::Array<EnvelopeHandleComponent*> handles;
@@ -249,11 +250,13 @@ private:
 	double valueGrid, domainGrid;
 	GridMode gridDisplayMode, gridQuantiseMode;
 	EnvelopeHandleComponent* draggingHandle;
+	EnvelopeHandleComponent* adjustingHandle;
+	double prevCurveValue = 0.0;
 	int curvePoints;
 	int releaseNode, loopNode;
 	
-	bool allowCurveEditing:1;
-	bool allowNodeEditing:1;
+	bool allowCurveEditing = false;
+	bool allowNodeEditing = false;
 	
 	juce::Colour colours[NumEnvColours];
 };

--- a/Source/UGen/ugen_JuceEnvelopeComponent.h
+++ b/Source/UGen/ugen_JuceEnvelopeComponent.h
@@ -215,6 +215,9 @@ public:
 	bool getAllowCurveEditing() const;
 	void setAllowNodeEditing(const bool flag);
 	bool getAllowNodeEditing() const;
+	void setAdsrMode(const bool adsrMode);
+	bool getAdsrMode() const;
+
 	
 	double convertPixelsToDomain(int pixelsX, int pixelsXMax = -1) const;
 	double convertPixelsToValue(int pixelsY, int pixelsYMax = -1) const;
@@ -258,6 +261,7 @@ private:
 	
 	bool allowCurveEditing = false;
 	bool allowNodeEditing = false;
+	bool adsrMode = false;
 	
 	juce::Colour colours[NumEnvColours];
 };
@@ -345,6 +349,7 @@ public:
 	bool getAllowCurveEditing() const			{ return envelope->getAllowCurveEditing();	}
 	void setAllowNodeEditing(const bool flag)	{ envelope->setAllowNodeEditing(flag);		}
 	bool getAllowNodeEditing() const			{ return envelope->getAllowNodeEditing();	}
+	void setAdsrMode(const bool adsrMode)		{ envelope->setAdsrMode(adsrMode);			}
 
 	
 private:

--- a/Source/UGen/ugen_JuceEnvelopeComponent.h
+++ b/Source/UGen/ugen_JuceEnvelopeComponent.h
@@ -1,0 +1,434 @@
+// $Id$
+// $HeadURL$
+
+/*
+ ==============================================================================
+ 
+ This file is part of the UGEN++ library
+ Copyright 2008-11 The University of the West of England.
+ by Martin Robinson
+ 
+ ------------------------------------------------------------------------------
+ 
+ UGEN++ can be redistributed and/or modified under the terms of the
+ GNU General Public License, as published by the Free Software Foundation;
+ either version 2 of the License, or (at your option) any later version.
+ 
+ UGEN++ is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with UGEN++; if not, visit www.gnu.org/licenses or write to the
+ Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ Boston, MA 02111-1307 USA
+ 
+ The idea for this project and code in the UGen implementations is
+ derived from SuperCollider which is also released under the 
+ GNU General Public License:
+ 
+ SuperCollider real time audio synthesis system
+ Copyright (c) 2002 James McCartney. All rights reserved.
+ http://www.audiosynth.com
+ 
+ ==============================================================================
+ */
+
+#ifndef UGEN_JUCEENVELOPECOMPONENT_H
+#define UGEN_JUCEENVELOPECOMPONENT_H
+
+#ifndef UGEN_NOEXTGPL
+
+#include <JuceHeader.h>
+#include "ugen_JuceUtility.h"
+#include "Env.h"
+#include "EnvCurve.h"
+
+
+#define HANDLESIZE 7
+#define FINETUNE 0.001
+
+//#define MYDEBUG 1 // get rid of this later
+
+class EnvelopeComponent;
+class EnvelopeHandleComponent;
+class EnvelopeLegendComponent;
+
+class EnvelopeHandleComponentConstrainer :	public juce::ComponentBoundsConstrainer
+{
+public:
+	EnvelopeHandleComponentConstrainer(EnvelopeHandleComponent* handle);
+	
+	void checkBounds (juce::Rectangle<int>& bounds,
+					  const juce::Rectangle<int>& old, const juce::Rectangle<int>& limits,
+					  bool isStretchingTop, bool isStretchingLeft,
+					  bool isStretchingBottom, bool isStretchingRight);
+	
+	void setAdjacentHandleLimits(int setLeftLimit, int setRightLimit);
+	
+private:
+	int leftLimit, rightLimit;
+	EnvelopeHandleComponent* handle;
+};
+
+class EnvelopeHandleComponent :	public juce::Component
+{
+public:	
+	EnvelopeHandleComponent();
+	EnvelopeComponent* getParentComponent() const;
+	
+	void updateTimeAndValue();
+	
+	void updateLegend();
+	void paint(juce::Graphics& g);
+	void moved();
+		
+	void mouseMove         (const juce::MouseEvent& e);
+    void mouseEnter        (const juce::MouseEvent& e);
+    void mouseExit         (const juce::MouseEvent& e);
+    void mouseDown         (const juce::MouseEvent& e);
+    void mouseDrag         (const juce::MouseEvent& e);
+    void mouseUp           (const juce::MouseEvent& e);
+		
+	EnvelopeHandleComponent* getPreviousHandle() const;
+	EnvelopeHandleComponent* getNextHandle() const;
+	void removeThisHandle();
+	
+	void setMousePositionToThisHandle();
+	
+	void resetOffsets() { offsetX = offsetY = 0; }
+	double getTime() const	{ return time;	}
+	double getValue() const	{ return value; }
+	EnvCurve getCurve() const	{ return curve; }
+	int getHandleIndex() const;
+		
+	void setTime(double timeToSet);
+	void setValue(double valueToSet);
+	void setCurve(EnvCurve curveToSet);
+	void setTimeAndValue(double timeToSet, double valueToSet, double quantise = 0.0);
+	void offsetTimeAndValue(double offsetTime, double offsetValue, double quantise = 0.0);
+	double constrainDomain(double domainToConstrain) const;
+	double constrainValue(double valueToConstrain) const;
+    
+    void lockTime(double time);
+    void lockValue(double value);
+    void unlockTime();
+    void unlockValue();
+	
+	friend class EnvelopeComponent;
+	
+private:
+	bool dontUpdateTimeAndValue;
+	void recalculatePosition();
+	
+	juce::ComponentDragger dragger;
+	int lastX, lastY;
+	int offsetX, offsetY;
+	EnvelopeHandleComponentConstrainer resizeLimits;
+	
+	double time, value;
+    bool shouldLockTime, shouldLockValue;
+	EnvCurve curve;
+	bool ignoreDrag;
+};
+
+
+class EnvelopeComponentListener
+{
+public:
+	EnvelopeComponentListener() throw() {}
+	virtual ~EnvelopeComponentListener() {}
+	virtual void envelopeChanged(EnvelopeComponent* changedEnvelope) = 0;
+    virtual void envelopeStartDrag(EnvelopeComponent*) { }
+    virtual void envelopeEndDrag(EnvelopeComponent*) { }
+};
+
+/** For displaying and editing a breakpoint envelope. 
+ @ingoup EnvUGens
+ @see Env */
+class EnvelopeComponent : public juce::Component
+{
+public:
+	EnvelopeComponent();
+	~EnvelopeComponent();
+	
+	void setDomainRange(const double min, const double max);
+	void setDomainRange(const double max) { setDomainRange(0.0, max); }
+	void getDomainRange(double& min, double& max) const;
+	void setValueRange(const double min, const double max);
+	void setValueRange(const double max) { setValueRange(0.0, max); }
+	void getValueRange(double& min, double& max) const;
+	
+	enum GridMode { 
+		GridLeaveUnchanged = -1,
+		GridNone = 0,
+		GridValue = 1, 
+		GridDomain = 2, 
+		GridBoth = GridValue | GridDomain 
+	};
+	void setGrid(const GridMode display, const GridMode quantise, const double domain = 0.0, const double value = 0.0);
+	void getGrid(GridMode& display, GridMode& quantise, double& domain, double& value) const;
+	
+	void paint(juce::Graphics& g);
+	void paintBackground(juce::Graphics& g);
+	void resized();
+		
+	void mouseMove         (const juce::MouseEvent& e);
+    void mouseEnter        (const juce::MouseEvent& e);
+	void mouseDown         (const juce::MouseEvent& e);
+	void mouseDrag         (const juce::MouseEvent& e);
+	void mouseUp           (const juce::MouseEvent& e);
+	
+	void addListener (EnvelopeComponentListener* const listener);
+    void removeListener (EnvelopeComponentListener* const listener);
+	void sendChangeMessage();
+    void sendStartDrag();
+    void sendEndDrag();
+	
+    void clear();
+    
+	EnvelopeLegendComponent* getLegend();
+	void setLegendText(juce::String legendText);
+	void setLegendTextToDefault();
+	int getHandleIndex(EnvelopeHandleComponent* handle) const;
+	EnvelopeHandleComponent* getHandle(const int index) const;
+    int getNumHandles() const { return handles.size(); }
+	
+	EnvelopeHandleComponent* getPreviousHandle(const EnvelopeHandleComponent* thisHandle) const;
+	EnvelopeHandleComponent* getNextHandle(const EnvelopeHandleComponent* thisHandle) const;
+	EnvelopeHandleComponent* addHandle(int newX, int newY, EnvCurve curve);
+	EnvelopeHandleComponent* addHandle(double newDomain, double newValue, EnvCurve curve);
+	void removeHandle(EnvelopeHandleComponent* thisHandle);
+	void quantiseHandle(EnvelopeHandleComponent* thisHandle);
+	
+	bool isReleaseNode(EnvelopeHandleComponent* thisHandle) const;
+	bool isLoopNode(EnvelopeHandleComponent* thisHandle) const;
+	void setReleaseNode(const int index);
+	void setReleaseNode(EnvelopeHandleComponent* thisHandle);
+	int getReleaseNode() const;
+	void setLoopNode(const int index);
+	void setLoopNode(EnvelopeHandleComponent* thisHandle);
+	int getLoopNode() const;
+	
+	void setAllowCurveEditing(const bool flag);
+	bool getAllowCurveEditing() const;
+	void setAllowNodeEditing(const bool flag);
+	bool getAllowNodeEditing() const;
+	
+	double convertPixelsToDomain(int pixelsX, int pixelsXMax = -1) const;
+	double convertPixelsToValue(int pixelsY, int pixelsYMax = -1) const;
+	double convertDomainToPixels(double domainValue) const;
+	double convertValueToPixels(double value) const;
+	
+	Env getEnv() const;
+	void setEnv(Env const& env);
+	float lookup(const float time) const;
+	void setMinMaxNumHandles(int min, int max);
+	
+	double constrainDomain(double domainToConstrain) const;
+	double constrainValue(double valueToConstrain) const;
+	
+//	double quantiseDomain(double value);
+//	double quantiseValue(double value);
+	
+	enum EnvColours { Node, ReleaseNode, LoopNode, Line, LoopLine, Background, GridLine, LegendText, LegendBackground, NumEnvColours };
+	void setEnvColour(const EnvColours which, juce::Colour colour) throw();
+	const juce::Colour getEnvColour(const EnvColours which) const throw();
+	
+	enum MoveMode { MoveClip, MoveSlide, NumMoveModes };
+	
+private:
+	void recalculateHandles();
+	
+	juce::SortedSet <void*> listeners;
+	juce::Array<EnvelopeHandleComponent*> handles;
+	int minNumHandles, maxNumHandles;
+	double domainMin, domainMax;
+	double valueMin, valueMax;
+	double valueGrid, domainGrid;
+	GridMode gridDisplayMode, gridQuantiseMode;
+	EnvelopeHandleComponent* draggingHandle;
+	int curvePoints;
+	int releaseNode, loopNode;
+	
+	bool allowCurveEditing:1;
+	bool allowNodeEditing:1;
+	
+	juce::Colour colours[NumEnvColours];
+};
+
+class EnvelopeLegendComponent : public juce::Component
+{
+public:
+	EnvelopeLegendComponent(juce::String defaultText = juce::String());
+	virtual ~EnvelopeLegendComponent() noexcept;
+	
+	EnvelopeComponent* getEnvelopeComponent() const;
+	
+	void paint(juce::Graphics& g);
+	void resized();
+	void setText(juce::String legendText);
+	void setText();
+	
+	virtual double mapValue(double value);
+	virtual double mapTime(double time);
+	virtual juce::String getValueUnits() { return juce::String(); }
+	virtual juce::String getTimeUnits() { return juce::String(); }
+	
+private:
+	juce::Label* text;
+	juce::String defaultText;
+};
+
+/** For displaying and editing a breakpoint envelope with a legend. 
+ This provides additional information about the points. 
+ @ingoup EnvUGens
+ @see Env */
+class EnvelopeContainerComponent : public juce::Component
+{
+public:
+	EnvelopeContainerComponent(juce::String defaultText = juce::String());
+	~EnvelopeContainerComponent();
+	void resized();
+	
+	EnvelopeComponent* getEnvelopeComponent() const		{ return envelope; }
+	EnvelopeLegendComponent* getLegendComponent() const	{ return legend;   }
+	void setLegendComponent(EnvelopeLegendComponent* newLegend);
+	
+	
+	void addListener (EnvelopeComponentListener* const listener) { envelope->addListener(listener); }
+    void removeListener (EnvelopeComponentListener* const listener) { envelope->removeListener(listener); }
+	
+	Env getEnv() const { return getEnvelopeComponent()->getEnv(); }
+	void setEnv(Env const& env) { return getEnvelopeComponent()->setEnv(env); }
+	float lookup(const float time) const { return getEnvelopeComponent()->lookup(time); }
+	
+	void setEnvColour(const EnvelopeComponent::EnvColours which, juce::Colour const& colour) throw()
+	{
+		envelope->setEnvColour(which, colour);
+	}
+	
+	const juce::Colour getEnvColour(const EnvelopeComponent::EnvColours which) const throw()
+	{
+		return envelope->getEnvColour(which);
+	}
+	
+	void setDomainRange(const double min, const double max)		{ envelope->setDomainRange(min, max);	}
+	void setDomainRange(const double max)						{ setDomainRange(0.0, max);				}
+	void getDomainRange(double& min, double& max) const			{ envelope->getDomainRange(min, max);	}
+	void setValueRange(const double min, const double max)		{ envelope->setValueRange(min, max);	} 
+	void setValueRange(const double max)						{ setValueRange(0.0, max);				}
+	void getValueRange(double& min, double& max) const			{ envelope->getValueRange(min, max);	}
+	
+	void setGrid(const EnvelopeComponent::GridMode display, 
+				 const EnvelopeComponent::GridMode quantise, 
+				 const double domain = 0.0, 
+				 const double value = 0.0)
+	{
+		envelope->setGrid(display, quantise, domain, value);
+	}
+	
+	void getGrid(EnvelopeComponent::GridMode& display, 
+				 EnvelopeComponent::GridMode& quantise,
+				 double& domain, 
+				 double& value) const
+	{
+		envelope->getGrid(display, quantise, domain, value);
+	}
+	
+	void setAllowCurveEditing(const bool flag)	{ envelope->setAllowCurveEditing(flag);		}
+	bool getAllowCurveEditing() const			{ return envelope->getAllowCurveEditing();	}
+	void setAllowNodeEditing(const bool flag)	{ envelope->setAllowNodeEditing(flag);		}
+	bool getAllowNodeEditing() const			{ return envelope->getAllowNodeEditing();	}
+
+	
+private:
+	EnvelopeComponent*			envelope;
+	EnvelopeLegendComponent*	legend;
+};
+
+class EnvelopeCurvePopup :	public PopupComponent,
+	public juce::Slider::Listener,
+	public juce::ComboBox::Listener
+{
+private:
+	
+	class CurveSlider : public juce::Slider
+	{
+	public:
+		inline double linlin(const double input, 
+			const double inLow, const double inHigh,
+			const double outLow, const double outHigh) throw()
+		{
+			double inRange = inHigh - inLow;
+			double outRange = outHigh - outLow;
+			return (input - inLow) * outRange / inRange + outLow;
+		}
+
+		CurveSlider() : juce::Slider("CurveSlider") { }
+        
+#if JUCE_MAJOR_VERSION < 2
+        const
+#endif
+			juce::String getTextFromValue (double value)
+		{
+			value = value * value * value;
+			value = linlin(value, -1.0, 1.0, -50.0, 50.0);
+			return juce::String(value, 6);
+		}
+	};
+	
+	EnvelopeHandleComponent* handle;
+	juce::Slider *slider;
+	juce::ComboBox *combo;
+	
+	bool initialised;
+	
+	static const int idOffset;
+
+	EnvelopeCurvePopup(EnvelopeHandleComponent* handle);
+	
+public:	
+	static void create(EnvelopeHandleComponent* handle, int x, int y);
+	
+	~EnvelopeCurvePopup();
+	void resized();
+	void sliderValueChanged(juce::Slider* sliderThatChanged);
+	void comboBoxChanged (juce::ComboBox* comboBoxThatHasChanged);
+    void expired();
+	
+};
+
+class EnvelopeNodePopup :	public PopupComponent,
+	public juce::ComboBox::Listener,
+	public juce::Button::Listener
+{
+private:
+	EnvelopeHandleComponent* handle;
+	juce::ComboBox *combo;
+	juce::TextButton *setLoopButton;
+	juce::TextButton *setReleaseButton;
+	
+	bool initialised;
+	
+	static const int idOffset;
+	
+	EnvelopeNodePopup(EnvelopeHandleComponent* handle);
+	
+public:	
+	enum NodeType { Normal, Release, Loop, ReleaseAndLoop };
+	
+	static void create(EnvelopeHandleComponent* handle, int x, int y);
+	
+	~EnvelopeNodePopup();
+	void resized();
+	void comboBoxChanged (juce::ComboBox* comboBoxThatHasChanged);
+	void buttonClicked(juce::Button *button);
+    void expired();
+};
+
+#endif // gpl
+
+
+#endif //UGEN_JUCEENVELOPECOMPONENT_H

--- a/Source/UGen/ugen_JuceEnvelopeComponent.h
+++ b/Source/UGen/ugen_JuceEnvelopeComponent.h
@@ -251,6 +251,7 @@ private:
 	GridMode gridDisplayMode, gridQuantiseMode;
 	EnvelopeHandleComponent* draggingHandle;
 	EnvelopeHandleComponent* adjustingHandle;
+	bool adjustable = false;
 	double prevCurveValue = 0.0;
 	int curvePoints;
 	int releaseNode, loopNode;

--- a/Source/UGen/ugen_JuceUtility.cpp
+++ b/Source/UGen/ugen_JuceUtility.cpp
@@ -35,8 +35,6 @@
  ==============================================================================
  */
 
-#include "../core/ugen_StandardHeader.h"
-
 #include "ugen_JuceUtility.h"
 
 PopupComponent::PopupComponent(const int max) 

--- a/Source/UGen/ugen_JuceUtility.cpp
+++ b/Source/UGen/ugen_JuceUtility.cpp
@@ -1,0 +1,94 @@
+// $Id$
+// $HeadURL$
+
+/*
+ ==============================================================================
+ 
+ This file is part of the UGEN++ library
+ Copyright 2008-11 The University of the West of England.
+ by Martin Robinson
+ 
+ ------------------------------------------------------------------------------
+ 
+ UGEN++ can be redistributed and/or modified under the terms of the
+ GNU General Public License, as published by the Free Software Foundation;
+ either version 2 of the License, or (at your option) any later version.
+ 
+ UGEN++ is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with UGEN++; if not, visit www.gnu.org/licenses or write to the
+ Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ Boston, MA 02111-1307 USA
+ 
+ The idea for this project and code in the UGen implementations is
+ derived from SuperCollider which is also released under the 
+ GNU General Public License:
+ 
+ SuperCollider real time audio synthesis system
+ Copyright (c) 2002 James McCartney. All rights reserved.
+ http://www.audiosynth.com
+ 
+ ==============================================================================
+ */
+
+#include "../core/ugen_StandardHeader.h"
+
+#include "ugen_JuceUtility.h"
+
+PopupComponent::PopupComponent(const int max) 
+:	maxCount(max) 
+{
+	activePopups++;
+	startTimer(100);
+}
+
+PopupComponent::~PopupComponent()
+{
+	activePopups--;
+}
+
+void PopupComponent::paint(juce::Graphics &g)
+{
+	g.setColour(juce::Colour::greyLevel(0.5).withAlpha(0.75f));
+	g.fillRoundedRectangle(0, 0, getWidth(), getHeight(), 5);
+}	
+
+void PopupComponent::mouseDown(juce::MouseEvent const& e)
+{
+	(void)e;
+	resetCounter();
+}	
+
+void PopupComponent::resetCounter()
+{
+	counter = maxCount;
+}
+
+void PopupComponent::timerCallback()
+{
+	if(Component::getNumCurrentlyModalComponents() > 0 && counter >= 0)
+	{
+		resetCounter();
+	}
+	else
+	{
+		counter--;		
+		if(counter < 0)
+		{
+			stopTimer();
+			delete this;
+		}
+	}
+}
+
+void PopupComponent::expire()
+{
+    expired();
+	counter = -1;
+}
+
+int PopupComponent::activePopups = 0;

--- a/Source/UGen/ugen_JuceUtility.h
+++ b/Source/UGen/ugen_JuceUtility.h
@@ -1,0 +1,68 @@
+// $Id$
+// $HeadURL$
+
+/*
+ ==============================================================================
+ 
+ This file is part of the UGEN++ library
+ Copyright 2008-11 The University of the West of England.
+ by Martin Robinson
+ 
+ ------------------------------------------------------------------------------
+ 
+ UGEN++ can be redistributed and/or modified under the terms of the
+ GNU General Public License, as published by the Free Software Foundation;
+ either version 2 of the License, or (at your option) any later version.
+ 
+ UGEN++ is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with UGEN++; if not, visit www.gnu.org/licenses or write to the
+ Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ Boston, MA 02111-1307 USA
+ 
+ The idea for this project and code in the UGen implementations is
+ derived from SuperCollider which is also released under the 
+ GNU General Public License:
+ 
+ SuperCollider real time audio synthesis system
+ Copyright (c) 2002 James McCartney. All rights reserved.
+ http://www.audiosynth.com
+ 
+ ==============================================================================
+ */
+
+#ifndef _UGEN_ugen_JuceUtility_H_
+#define _UGEN_ugen_JuceUtility_H_
+
+#include <JuceHeader.h>
+
+/** A little Juce class used as a pop-up editor. */
+class PopupComponent :	public juce::Component,
+						public juce::Timer
+{
+private:
+	int counter;
+	const int maxCount; 	
+	static int activePopups;
+	
+public:
+	PopupComponent(const int max = 20);	
+	~PopupComponent();
+	void paint(juce::Graphics &g);	
+	void mouseDown(juce::MouseEvent const& e);
+    
+    virtual void expired() = 0;
+	
+	static int getActivePopups() { return activePopups; }
+
+protected:
+	void resetCounter();	
+	void timerCallback();
+	void expire();
+};
+
+#endif // _UGEN_ugen_JuceUtility_H_

--- a/Source/audio/ShapeVoice.h
+++ b/Source/audio/ShapeVoice.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <JuceHeader.h>
 #include "ShapeSound.h"
+#include "../UGen/Env.h"
 
 class OscirenderAudioProcessor;
 class ShapeVoice : public juce::SynthesiserVoice {
@@ -34,6 +35,11 @@ private:
 	double lengthIncrement = 0.0;
 
     bool currentlyPlaying = false;
-	double tailOff = 0.0;
 	double frequency = 1.0;
+
+	Env adsr;
+	double time = 0.0;
+	double releaseTime = 0.0;
+	double endTime = 99999999;
+	bool waitingForRelease = false;
 };

--- a/osci-render.jucer
+++ b/osci-render.jucer
@@ -452,6 +452,20 @@
       <FILE id="UxZu4n" name="TxtComponent.cpp" compile="1" resource="0"
             file="Source/TxtComponent.cpp"/>
       <FILE id="kxPbsL" name="TxtComponent.h" compile="0" resource="0" file="Source/TxtComponent.h"/>
+      <GROUP id="{0C40BD3D-FDE8-D3CD-E1AB-14CA04799E4A}" name="UGen">
+        <FILE id="zfNA3c" name="Env.cpp" compile="1" resource="0" file="Source/UGen/Env.cpp"/>
+        <FILE id="DHCLp1" name="Env.h" compile="0" resource="0" file="Source/UGen/Env.h"/>
+        <FILE id="K4CI4M" name="EnvCurve.cpp" compile="1" resource="0" file="Source/UGen/EnvCurve.cpp"/>
+        <FILE id="w3bgas" name="EnvCurve.h" compile="0" resource="0" file="Source/UGen/EnvCurve.h"/>
+        <FILE id="aBbEWE" name="ugen_JuceEnvelopeComponent.cpp" compile="1"
+              resource="0" file="Source/UGen/ugen_JuceEnvelopeComponent.cpp"/>
+        <FILE id="ayzzMJ" name="ugen_JuceEnvelopeComponent.h" compile="0" resource="0"
+              file="Source/UGen/ugen_JuceEnvelopeComponent.h"/>
+        <FILE id="eOA8hh" name="ugen_JuceUtility.cpp" compile="1" resource="0"
+              file="Source/UGen/ugen_JuceUtility.cpp"/>
+        <FILE id="mC1tUv" name="ugen_JuceUtility.h" compile="0" resource="0"
+              file="Source/UGen/ugen_JuceUtility.h"/>
+      </GROUP>
     </GROUP>
   </MAINGROUP>
   <JUCEOPTIONS JUCE_STRICT_REFCOUNTEDPOINTER="1" JUCE_VST3_CAN_REPLACE_VST2="0"/>


### PR DESCRIPTION
- ADSR (Attack, Decay, Sustain, Release) envelope added in MIDI section
- Points on the envelope can be dragged around to change the dynamics of notes played
- You can drag the curve itself to change its shape
- Doesn't affect anything if Enable MIDI is disabled

STILL TODO:
- Make it look good
- Add meaningful labels on the points of the graph
  - i.e. Attack, Decay, etc.
- Add a grid so you can more precisely time it

![image](https://github.com/jameshball/osci-render-juce/assets/38670946/828d4e5f-3052-40fb-8818-502cca7925f8)
